### PR TITLE
Log exchange balances on opening and closing trades

### DIFF
--- a/src/main/java/com/r307/arbitrader/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/TradingService.java
@@ -222,6 +222,9 @@ public class TradingService {
                             LOGGER.debug("Not enough liquidity to execute both trades profitably");
                         } else {
                             LOGGER.info("***** ENTRY *****");
+
+                            logCurrentExchangeBalances(longExchange, shortExchange);
+
                             LOGGER.info("Exit spread target: {}", exitTarget);
                             LOGGER.info("Long entry: {} {} {} @ {} ({} slip) = {}{}",
                                     longExchange.getExchangeSpecification().getExchangeName(),
@@ -323,18 +326,7 @@ public class TradingService {
                             LOGGER.error("IOE executing limit orders: ", e);
                         }
 
-                        try {
-                            BigDecimal longBalance = getAccountBalance(longExchange);
-                            BigDecimal shortBalance = getAccountBalance(shortExchange);
-
-                            LOGGER.info("Updated account balances: {} ${} / {} ${}",
-                                    longExchange.getExchangeSpecification().getExchangeName(),
-                                    longBalance,
-                                    shortExchange.getExchangeSpecification().getExchangeName(),
-                                    shortBalance);
-                        } catch (IOException e) {
-                            LOGGER.error("IOE fetching account balances: ", e);
-                        }
+                        logCurrentExchangeBalances(longExchange, shortExchange);
 
                         inMarket = false;
                         activeCurrencyPair = null;
@@ -587,6 +579,22 @@ public class TradingService {
             return smallestBalance == null ? null : smallestBalance
                     .multiply(new BigDecimal(0.9))
                     .setScale(DecimalConstants.USD_SCALE, RoundingMode.HALF_EVEN);
+        }
+    }
+
+    private void logCurrentExchangeBalances(Exchange longExchange, Exchange shortExchange) {
+        try {
+            BigDecimal longBalance = getAccountBalance(longExchange);
+            BigDecimal shortBalance = getAccountBalance(shortExchange);
+
+            LOGGER.info("Updated account balances: {} ${} / {} ${} = ${}",
+                    longExchange.getExchangeSpecification().getExchangeName(),
+                    longBalance,
+                    shortExchange.getExchangeSpecification().getExchangeName(),
+                    shortBalance,
+                    longBalance.add(shortBalance));
+        } catch (IOException e) {
+            LOGGER.error("IOE fetching account balances: ", e);
         }
     }
 


### PR DESCRIPTION
I consider this change the first step toward more rigorous verification that the bot is reporting reliable numbers. It'll print out the account balances and their sum before entering the two positions, and again after exiting the two positions. Assuming the trades all opened and closed successfully the sums of the account balances will show for sure whether you gained or lost money overall. Once I have this kind of reporting I can start tracking back through the earlier estimates to make sure the math all adds up like it ought to.