### PR TITLE
Mount a dot folder instead of a file for metadata.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,4 +8,4 @@ services:
       - "5005:5005"
     volumes:
       - ${PWD}/application.yaml:/application.yaml
-      - ${PWD}/arbitrader-state.json:/arbitrader-state.json
+      - ${PWD}/.arbitrader:/.arbitrader

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -59,7 +59,7 @@ public class TradingService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TradingService.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String STATE_FILE = "arbitrader-state.json";
+    private static final String STATE_FILE = ".arbitrader/arbitrader-state.json";
 
     private TradingConfiguration tradingConfiguration;
     private NotificationConfiguration notificationConfiguration;


### PR DESCRIPTION
Fixes #61 

If the state file doesn't exist (e.g. on the first run) docker-compose will create a directory with the same name and mount that into the container. The bot will then be unable to write the file when it needs to. This makes a change to `docker-compose.yaml` and the path for the state file so that we now have a dot directory for Arbitrader which may be empty but can be mounted into the container and the bot will be able to write into it.