### PR TITLE
Optimize to reduce API calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.4.0-SNAPSHOT'
+version '0.5.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
+++ b/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
@@ -1,4 +1,4 @@
-package com.r307.arbitrader.service;
+package com.r307.arbitrader.service.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.knowm.xchange.Exchange;

--- a/src/main/java/com/r307/arbitrader/service/model/TradeCombination.java
+++ b/src/main/java/com/r307/arbitrader/service/model/TradeCombination.java
@@ -1,0 +1,53 @@
+package com.r307.arbitrader.service.model;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+
+import java.util.Objects;
+
+public class TradeCombination {
+    private Exchange longExchange;
+    private Exchange shortExchange;
+    private CurrencyPair currencyPair;
+
+    public TradeCombination(Exchange longExchange, Exchange shortExchange, CurrencyPair currencyPair) {
+        this.longExchange = longExchange;
+        this.shortExchange = shortExchange;
+        this.currencyPair = currencyPair;
+    }
+
+    public Exchange getLongExchange() {
+        return longExchange;
+    }
+
+    public Exchange getShortExchange() {
+        return shortExchange;
+    }
+
+    public CurrencyPair getCurrencyPair() {
+        return currencyPair;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TradeCombination)) return false;
+        TradeCombination that = (TradeCombination) o;
+        return Objects.equals(getLongExchange(), that.getLongExchange()) &&
+            Objects.equals(getShortExchange(), that.getShortExchange()) &&
+            Objects.equals(getCurrencyPair(), that.getCurrencyPair());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLongExchange(), getShortExchange(), getCurrencyPair());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s/%s %s",
+            longExchange.getExchangeSpecification().getExchangeName(),
+            shortExchange.getExchangeSpecification().getExchangeName(),
+            currencyPair.toString());
+    }
+}

--- a/src/test/java/com/r307/arbitrader/service/model/ActivePositionTest.java
+++ b/src/test/java/com/r307/arbitrader/service/model/ActivePositionTest.java
@@ -1,4 +1,4 @@
-package com.r307.arbitrader.service;
+package com.r307.arbitrader.service.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.r307.arbitrader.ExchangeBuilder;

--- a/src/test/java/com/r307/arbitrader/service/model/TradeCombinationTest.java
+++ b/src/test/java/com/r307/arbitrader/service/model/TradeCombinationTest.java
@@ -1,0 +1,34 @@
+package com.r307.arbitrader.service.model;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+
+public class TradeCombinationTest {
+    @Mock
+    private Exchange longExchange;
+
+    @Mock
+    private Exchange shortExchange;
+
+    private CurrencyPair currencyPair = CurrencyPair.BTC_USD;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testCreateAndGet() {
+        TradeCombination tradeCombination = new TradeCombination(longExchange, shortExchange, currencyPair);
+
+        assertEquals(longExchange, tradeCombination.getLongExchange());
+        assertEquals(shortExchange, tradeCombination.getShortExchange());
+        assertEquals(currencyPair, tradeCombination.getCurrencyPair());
+    }
+}


### PR DESCRIPTION
* Pre-compute the active trade combinations on startup instead of doing it every tick
* Only fetch tickers that are actually being used for trading