### PR TITLE
Force close position

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/ConditionService.java
+++ b/src/main/java/com/r307/arbitrader/service/ConditionService.java
@@ -1,0 +1,19 @@
+package com.r307.arbitrader.service;
+
+import org.apache.commons.io.FileUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@Component
+public class ConditionService {
+    private File forceCloseFile = new File("force-close");
+
+    public boolean isForceCloseCondition() {
+        return forceCloseFile.exists();
+    }
+
+    public void clearForceCloseCondition() {
+        FileUtils.deleteQuietly(forceCloseFile);
+    }
+}

--- a/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
+++ b/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
@@ -54,6 +54,16 @@ public class ActivePosition {
         return Objects.hash(getLongTrade(), getShortTrade(), getCurrencyPair(), getExitTarget());
     }
 
+    @Override
+    public String toString() {
+        return "ActivePosition{" +
+            "longTrade=" + longTrade +
+            ", shortTrade=" + shortTrade +
+            ", currencyPair=" + currencyPair +
+            ", exitTarget=" + exitTarget +
+            '}';
+    }
+
     public static class Trade {
         private String exchange;
         private String orderId;
@@ -110,6 +120,16 @@ public class ActivePosition {
         @Override
         public int hashCode() {
             return Objects.hash(getExchange(), getOrderId(), getVolume(), getEntry());
+        }
+
+        @Override
+        public String toString() {
+            return "Trade{" +
+                "exchange='" + exchange + '\'' +
+                ", orderId='" + orderId + '\'' +
+                ", volume=" + volume +
+                ", entry=" + entry +
+                '}';
         }
     }
 }

--- a/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
@@ -1,0 +1,53 @@
+package com.r307.arbitrader.service;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConditionServiceTest {
+    private ConditionService conditionService;
+
+    @Before
+    public void setUp() {
+        conditionService = new ConditionService();
+    }
+
+    @Test
+    public void testClearForceCloseConditionIdempotence() {
+        // it should not break if the condition is already clear
+        conditionService.clearForceCloseCondition();
+    }
+
+    @Test
+    public void testClearForceCloseCondition() throws IOException {
+        File forceClose = new File("force-close");
+
+        assertTrue(forceClose.createNewFile());
+        assertTrue(forceClose.exists());
+
+        conditionService.clearForceCloseCondition();
+
+        assertFalse(forceClose.exists());
+    }
+
+    @Test
+    public void testCheckForceCloseCondition() throws IOException {
+        File forceClose = new File("force-close");
+
+        assertFalse(forceClose.exists());
+        assertFalse(conditionService.isForceCloseCondition());
+
+        assertTrue(forceClose.createNewFile());
+
+        assertTrue(forceClose.exists());
+        assertTrue(conditionService.isForceCloseCondition());
+
+        FileUtils.deleteQuietly(forceClose);
+    }
+}

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -38,6 +38,7 @@ public class TradingServiceTest {
         tradingConfiguration = new TradingConfiguration();
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
         ExchangeFeeCache feeCache = new ExchangeFeeCache();
+        ConditionService conditionService = new ConditionService();
 
         longExchange = new ExchangeBuilder("Long", CurrencyPair.BTC_USD)
                 .withExchangeMetaData()
@@ -52,7 +53,11 @@ public class TradingServiceTest {
 
         // This spy right here is a bad code smell, kids! Don't try this at work!
         // Upcoming refactoring will allow me to remove it.
-        tradingService = spy(new TradingService(tradingConfiguration, notificationConfiguration, feeCache));
+        tradingService = spy(new TradingService(
+            tradingConfiguration,
+            notificationConfiguration,
+            feeCache,
+            conditionService));
     }
 
     @Test


### PR DESCRIPTION
Force the bot to close current positions immediately by creating an empty file named `force-close` in the directory where the bot is running. This can be useful if you are tired of waiting for a trade to close. 

It is also going to be very useful for me to test the logic around closing trades much more quickly than I have been able to in the past.

Fixes #35 