### PR TITLE
Accurate exit volumes

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -881,14 +881,14 @@ public class TradingService {
 
     BigDecimal getVolumeForOrder(Exchange exchange, CurrencyPair currencyPair, String orderId, BigDecimal defaultVolume) {
         try {
-            LOGGER.info("{}: Attempting to fetch volume from order by ID: {}", exchange.getExchangeSpecification().getExchangeName(), orderId);
+            LOGGER.debug("{}: Attempting to fetch volume from order by ID: {}", exchange.getExchangeSpecification().getExchangeName(), orderId);
             BigDecimal volume = exchange.getTradeService().getOrder(orderId)
                     .stream()
                     .findFirst()
                     .orElseThrow(() -> new OrderNotFoundException(orderId))
                     .getOriginalAmount();
 
-            LOGGER.info("{}: Order {} volume is: {}",
+            LOGGER.debug("{}: Order {} volume is: {}",
                 exchange.getExchangeSpecification().getExchangeName(),
                 orderId,
                 volume);
@@ -897,15 +897,15 @@ public class TradingService {
                 throw new IllegalStateException("Volume must be more than zero.");
             }
 
-            LOGGER.info("{}: Using volume: {}",
+            LOGGER.debug("{}: Using volume: {}",
                 exchange.getExchangeSpecification().getExchangeName(),
                 orderId);
 
             return volume;
         } catch (NotAvailableFromExchangeException e) {
-            LOGGER.info("{}: Does not support fetching orders by ID", exchange.getExchangeSpecification().getExchangeName());
+            LOGGER.debug("{}: Does not support fetching orders by ID", exchange.getExchangeSpecification().getExchangeName());
         } catch (IOException e) {
-            LOGGER.warn("{}: Unable to fetch order {}", exchange.getExchangeSpecification().getExchangeName(), orderId);
+            LOGGER.warn("{}: Unable to fetch order {}", exchange.getExchangeSpecification().getExchangeName(), orderId, e);
         } catch (IllegalStateException e) {
             LOGGER.debug(e.getMessage());
         }
@@ -914,15 +914,15 @@ public class TradingService {
             BigDecimal balance = getAccountBalance(exchange, currencyPair.base);
 
             if (BigDecimal.ZERO.compareTo(balance) < 0) {
-                LOGGER.info("{}: Using {} balance: {}", exchange.getExchangeSpecification().getExchangeName(), currencyPair.base.toString(), balance);
+                LOGGER.debug("{}: Using {} balance: {}", exchange.getExchangeSpecification().getExchangeName(), currencyPair.base.toString(), balance);
 
                 return balance;
             }
         } catch (IOException e) {
-            LOGGER.warn("{}: Unable to fetch {} account balance", exchange.getExchangeSpecification().getExchangeName(), currencyPair.base.toString());
+            LOGGER.warn("{}: Unable to fetch {} account balance", exchange.getExchangeSpecification().getExchangeName(), currencyPair.base.toString(), e);
         }
 
-        LOGGER.info("{}: Falling back to default volume: {}",
+        LOGGER.debug("{}: Falling back to default volume: {}",
             exchange.getExchangeSpecification().getExchangeName(),
             defaultVolume);
         return defaultVolume;

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -64,6 +64,7 @@ public class TradingServiceTest {
     public void testGetVolumeForOrder() {
         BigDecimal volume = tradingService.getVolumeForOrder(
                 longExchange,
+                currencyPair.counter,
                 "orderId",
                 new BigDecimal(50.0));
 
@@ -74,6 +75,7 @@ public class TradingServiceTest {
     public void testGetVolumeForOrderNotFound() {
         tradingService.getVolumeForOrder(
                 longExchange,
+                currencyPair.counter,
                 "missingOrder",
                 new BigDecimal(50.0));
     }
@@ -82,6 +84,7 @@ public class TradingServiceTest {
     public void testGetVolumeForOrderNotAvailable() {
         BigDecimal volume = tradingService.getVolumeForOrder(
                 longExchange,
+                currencyPair.counter,
                 "notAvailable",
                 new BigDecimal(50.0));
 
@@ -92,6 +95,7 @@ public class TradingServiceTest {
     public void testGetVolumeForOrderIOException() {
         BigDecimal volume = tradingService.getVolumeForOrder(
                 longExchange,
+                currencyPair.counter,
                 "ioe",
                 new BigDecimal(50.0));
 

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -64,7 +64,7 @@ public class TradingServiceTest {
     public void testGetVolumeForOrder() {
         BigDecimal volume = tradingService.getVolumeForOrder(
                 longExchange,
-                currencyPair.counter,
+                currencyPair,
                 "orderId",
                 new BigDecimal(50.0));
 
@@ -75,29 +75,67 @@ public class TradingServiceTest {
     public void testGetVolumeForOrderNotFound() {
         tradingService.getVolumeForOrder(
                 longExchange,
-                currencyPair.counter,
+                currencyPair,
                 "missingOrder",
                 new BigDecimal(50.0));
     }
 
     @Test
-    public void testGetVolumeForOrderNotAvailable() {
+    public void testGetVolumeForOrderNotAvailable() throws IOException {
+        doReturn(new BigDecimal(90.0))
+            .when(tradingService)
+            .getAccountBalance(any(Exchange.class), any(Currency.class), anyInt());
+
         BigDecimal volume = tradingService.getVolumeForOrder(
                 longExchange,
-                currencyPair.counter,
+                currencyPair,
                 "notAvailable",
                 new BigDecimal(50.0));
+
+        assertEquals(new BigDecimal(90.0), volume);
+    }
+
+    @Test
+    public void testGetVolumeForOrderIOException() throws IOException {
+        doReturn(new BigDecimal(90.0))
+            .when(tradingService)
+            .getAccountBalance(any(Exchange.class), any(Currency.class), anyInt());
+
+        BigDecimal volume = tradingService.getVolumeForOrder(
+                longExchange,
+                currencyPair,
+                "ioe",
+                new BigDecimal(50.0));
+
+        assertEquals(new BigDecimal(90.0), volume);
+    }
+
+    @Test
+    public void testGetVolumeFallbackToDefaultZeroBalance() throws IOException {
+        doReturn(BigDecimal.ZERO)
+            .when(tradingService)
+            .getAccountBalance(any(Exchange.class), any(Currency.class), anyInt());
+
+        BigDecimal volume = tradingService.getVolumeForOrder(
+            longExchange,
+            currencyPair,
+            "notAvailable",
+            new BigDecimal(50.0));
 
         assertEquals(new BigDecimal(50.0), volume);
     }
 
     @Test
-    public void testGetVolumeForOrderIOException() {
+    public void testGetVolumeFallbackToDefaultIOException() throws IOException {
+        doThrow(new IOException("Boom!"))
+            .when(tradingService)
+            .getAccountBalance(any(Exchange.class), any(Currency.class), anyInt());
+
         BigDecimal volume = tradingService.getVolumeForOrder(
-                longExchange,
-                currencyPair.counter,
-                "ioe",
-                new BigDecimal(50.0));
+            longExchange,
+            currencyPair,
+            "notAvailable",
+            new BigDecimal(50.0));
 
         assertEquals(new BigDecimal(50.0), volume);
     }


### PR DESCRIPTION
Exiting positions on some exchanges wasn't working reliably because the trade volume was being computed as greater than the available currency. The old algorithm was:

* Check the open order on the exchange and use its volume
* Failing that, use the volume we remembered from when we entered the position

Unfortunately for Poloniex (possibly others) we couldn't look up the order and the available balance was less than the entry volume due to fees. This PR adds a middle step to check the account balance in the base cryptocurrency to see if we can get the total available amount. If it comes out to zero or throws an exception, only then do we fall back to the remembered volume.