### PR TITLE
PR merge builds appear to be failing

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,8 +19,13 @@ phases:
   build:
     commands:
       - docker build -t scionaltera/arbitrader:latest -f src/main/docker/codebuild/Dockerfile .
-      - docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION}
-      - docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+      - echo "CodeBuild Initiator is ${CODEBUILD_INITIATOR}"
+      - |
+        if expr "${CODEBUILD_INITIATOR}" : "codepipeline*" >/dev/null; then
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION}
+        else
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+        fi
   post_build:
     commands:
       - echo "CodeBuild Initiator is ${CODEBUILD_INITIATOR}"


### PR DESCRIPTION
It's trying to set a bad tag on the Docker image when it doesn't need to. This looks like something that used to work (it failed to set the tag but the build still completed successfully) but has changed so it now fails the entire build.

Unfortunately the only way to test this is to merge PRs into master, so this could end up taking a few tries...