### PR TITLE
Remind the user of the total USD balance from the start of a trade at…

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
+++ b/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
@@ -13,6 +13,7 @@ public class ActivePosition {
     private Trade shortTrade = new Trade();
     private CurrencyPair currencyPair;
     private BigDecimal exitTarget;
+    private BigDecimal entryBalance; // USD balance of both exchanges summed when the trades were first opened
 
     public Trade getLongTrade() {
         return longTrade;
@@ -38,6 +39,14 @@ public class ActivePosition {
         this.exitTarget = exitTarget;
     }
 
+    public BigDecimal getEntryBalance() {
+        return entryBalance;
+    }
+
+    public void setEntryBalance(BigDecimal entryBalance) {
+        this.entryBalance = entryBalance;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -46,12 +55,13 @@ public class ActivePosition {
         return Objects.equals(getLongTrade(), that.getLongTrade()) &&
             Objects.equals(getShortTrade(), that.getShortTrade()) &&
             Objects.equals(getCurrencyPair(), that.getCurrencyPair()) &&
-            Objects.equals(getExitTarget(), that.getExitTarget());
+            Objects.equals(getExitTarget(), that.getExitTarget()) &&
+            Objects.equals(getEntryBalance(), that.getEntryBalance());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getLongTrade(), getShortTrade(), getCurrencyPair(), getExitTarget());
+        return Objects.hash(getLongTrade(), getShortTrade(), getCurrencyPair(), getExitTarget(), getEntryBalance());
     }
 
     @Override
@@ -61,6 +71,7 @@ public class ActivePosition {
             ", shortTrade=" + shortTrade +
             ", currencyPair=" + currencyPair +
             ", exitTarget=" + exitTarget +
+            ", entryBalance=" + entryBalance +
             '}';
     }
 


### PR DESCRIPTION
… the end of the trade

It's not a complicated feature but it will make it so you don't have to scroll back up through hundreds of lines of logs to double check how well a trade really did. It will show you what the balance was when the trades were opened, then on the next line will be the current balance so you can easily see the difference. Having this little bit of extra information will help to debug the estimated profit calculation, which seems to be wrong a lot.