### PR TITLE
Exit when idle

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/ConditionService.java
+++ b/src/main/java/com/r307/arbitrader/service/ConditionService.java
@@ -7,7 +7,11 @@ import java.io.File;
 
 @Component
 public class ConditionService {
-    private File forceCloseFile = new File("force-close");
+    static final String FORCE_CLOSE = "force-close";
+    static final String EXIT_WHEN_IDLE = "exit-when-idle";
+
+    private File forceCloseFile = new File(FORCE_CLOSE);
+    private File exitWhenIdleFile = new File(EXIT_WHEN_IDLE);
 
     public boolean isForceCloseCondition() {
         return forceCloseFile.exists();
@@ -15,5 +19,13 @@ public class ConditionService {
 
     public void clearForceCloseCondition() {
         FileUtils.deleteQuietly(forceCloseFile);
+    }
+
+    public boolean isExitWhenIdleCondition() {
+        return exitWhenIdleFile.exists();
+    }
+
+    public void clearExitWhenIdleCondition() {
+        FileUtils.deleteQuietly(exitWhenIdleFile);
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -273,6 +273,12 @@ public class TradingService {
             System.exit(1);
         }
 
+        if (activePosition == null && conditionService.isExitWhenIdleCondition()) {
+            LOGGER.info("Exiting at user request");
+            conditionService.clearExitWhenIdleCondition();
+            System.exit(0);
+        }
+
         // fetch all the configured tickers for each exchange
         allTickers.clear();
 

--- a/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
+import static com.r307.arbitrader.service.ConditionService.EXIT_WHEN_IDLE;
+import static com.r307.arbitrader.service.ConditionService.FORCE_CLOSE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -26,7 +28,7 @@ public class ConditionServiceTest {
 
     @Test
     public void testClearForceCloseCondition() throws IOException {
-        File forceClose = new File("force-close");
+        File forceClose = new File(FORCE_CLOSE);
 
         assertTrue(forceClose.createNewFile());
         assertTrue(forceClose.exists());
@@ -38,7 +40,7 @@ public class ConditionServiceTest {
 
     @Test
     public void testCheckForceCloseCondition() throws IOException {
-        File forceClose = new File("force-close");
+        File forceClose = new File(FORCE_CLOSE);
 
         assertFalse(forceClose.exists());
         assertFalse(conditionService.isForceCloseCondition());
@@ -49,5 +51,37 @@ public class ConditionServiceTest {
         assertTrue(conditionService.isForceCloseCondition());
 
         FileUtils.deleteQuietly(forceClose);
+    }
+
+    @Test
+    public void testClearExitWhenIdleConditionIdempotence() {
+        conditionService.clearExitWhenIdleCondition();
+    }
+
+    @Test
+    public void testClearExitWhenIdleCondition() throws IOException {
+        File exitWhenIdle = new File(EXIT_WHEN_IDLE);
+
+        assertTrue(exitWhenIdle.createNewFile());
+        assertTrue(exitWhenIdle.exists());
+
+        conditionService.clearExitWhenIdleCondition();
+
+        assertFalse(exitWhenIdle.exists());
+    }
+
+    @Test
+    public void testCheckExitWhenIdleCondition() throws IOException {
+        File exitWhenIdle = new File(EXIT_WHEN_IDLE);
+
+        assertFalse(exitWhenIdle.exists());
+        assertFalse(conditionService.isExitWhenIdleCondition());
+
+        assertTrue(exitWhenIdle.createNewFile());
+
+        assertTrue(exitWhenIdle.exists());
+        assertTrue(conditionService.isExitWhenIdleCondition());
+
+        FileUtils.deleteQuietly(exitWhenIdle);
     }
 }


### PR DESCRIPTION
* Fixes #68
* Placing an empty file called "exit-when-idle" in Arbitrader's working directory will make it exit the next time there is no active trade