### PR TITLE
Stepped lot size

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -31,8 +31,8 @@ phases:
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         else
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:snapshot
-          docker push scionaltera/arbitrader:snapshot
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+          docker push scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json
 artifacts:

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -225,4 +225,34 @@ public class TradingServiceTest {
         // the IOE should not propagate and blow everything up
         assertEquals(new BigDecimal(0.00).setScale(USD_SCALE, RoundingMode.HALF_EVEN), exposure);
     }
+
+    @Test
+    public void testRoundByStep64() {
+        BigDecimal input = new BigDecimal(64.00);
+        BigDecimal step = new BigDecimal(10.00);
+
+        BigDecimal result = TradingService.roundByStep(input, step);
+
+        assertEquals(new BigDecimal(60.00), result);
+    }
+
+    @Test
+    public void testRoundByStep65() {
+        BigDecimal input = new BigDecimal(65.00);
+        BigDecimal step = new BigDecimal(10.00);
+
+        BigDecimal result = TradingService.roundByStep(input, step);
+
+        assertEquals(new BigDecimal(60.00), result);
+    }
+
+    @Test
+    public void testRoundByStep66() {
+        BigDecimal input = new BigDecimal(66.00);
+        BigDecimal step = new BigDecimal(10.00);
+
+        BigDecimal result = TradingService.roundByStep(input, step);
+
+        assertEquals(new BigDecimal(70.00), result);
+    }
 }


### PR DESCRIPTION
Some exchanges require trade sizes to be specific volumes (e.g. multiples of 0.01).

Fortunately XChange has a setting in the exchange metadata that indicates the lot size. This new feature will use that metadata, if it is present, to round off trades for that exchange to meet the required lot size.

Unfortunately none of the exchanges I use have this requirement so I can't test any live trades. This PR is blocked until @sanitariu or somebody else from the community has an opportunity to test it using an exchange that requires it, such as Binance.

To test, you may build from the `stepped-lot-size` branch or you can use the `scionaltera/arbitrader:stepped-lot-size` Docker tag. Post your log here to show that it used the correct lot sizes for a trade. Feel free to scrub other information like dollar amounts.