### PR TITLE
Bump to XChange 4.3.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,14 +35,14 @@ dependencies {
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
 
-    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-kraken', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-coinbasepro', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-gemini', version: '4.3.18'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '4.3.18'
+    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-kraken', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-coinbasepro', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-gemini', version: '4.3.19'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '4.3.19'
 
     compile group: 'com.github.seratch', name: 'jslack', version: '1.1.6'
     compile group: 'javax.websocket', name: 'javax.websocket-api', version: '1.1'


### PR DESCRIPTION
XChange 4.3.19 includes my fix for warnings from Bitflyer about badly formatted date strings.