### PR TITLE
Trading Blackout Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out/
 *.iml
 /application.yaml
 /arbitrader-state.json
+/blackout

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.6.2-SNAPSHOT'
+version '0.7.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/r307/arbitrader/service/ConditionService.java
+++ b/src/main/java/com/r307/arbitrader/service/ConditionService.java
@@ -1,17 +1,29 @@
 package com.r307.arbitrader.service;
 
 import org.apache.commons.io.FileUtils;
+import org.knowm.xchange.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Component
 public class ConditionService {
     static final String FORCE_CLOSE = "force-close";
     static final String EXIT_WHEN_IDLE = "exit-when-idle";
+    static final String BLACKOUT = "blackout";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConditionService.class);
 
     private File forceCloseFile = new File(FORCE_CLOSE);
     private File exitWhenIdleFile = new File(EXIT_WHEN_IDLE);
+    private File blackoutFile = new File(BLACKOUT);
 
     public boolean isForceCloseCondition() {
         return forceCloseFile.exists();
@@ -27,5 +39,39 @@ public class ConditionService {
 
     public void clearExitWhenIdleCondition() {
         FileUtils.deleteQuietly(exitWhenIdleFile);
+    }
+
+    public boolean isBlackoutCondition(Exchange exchange) {
+        if (!blackoutFile.exists() || !blackoutFile.canRead()) {
+            return false;
+        }
+
+        try {
+            List<String> lines = FileUtils.readLines(blackoutFile, Charset.defaultCharset());
+
+            return lines
+                .stream()
+                .filter(line -> line.startsWith(exchange.getExchangeSpecification().getExchangeName()))
+                .anyMatch(this::checkBlackoutWindow);
+
+        } catch (IOException e) {
+            LOGGER.error("Blackout file exists but cannot be read!", e);
+        }
+
+        return false;
+    }
+
+    private boolean checkBlackoutWindow(String line) {
+        String[] dateStrings = line.split("[,]");
+
+        if (dateStrings.length != 3) {
+            return false;
+        }
+
+        ZonedDateTime start = ZonedDateTime.parse(dateStrings[1], DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        ZonedDateTime end = ZonedDateTime.parse(dateStrings[2], DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        ZonedDateTime now = ZonedDateTime.now();
+
+        return now.isAfter(start) && now.isBefore(end);
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -464,6 +464,8 @@ public class TradingService {
 
                 if (spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
                     LOGGER.debug("Not enough liquidity to execute both trades profitably");
+                } else if (conditionService.isBlackoutCondition(longExchange) || conditionService.isBlackoutCondition(shortExchange)) {
+                    LOGGER.warn("Cannot open position on one or more exchanges due to user configured blackout");
                 } else {
                     LOGGER.info("***** ENTRY *****");
 
@@ -549,7 +551,9 @@ public class TradingService {
                     LOGGER.error("Computed trade volume for exiting position was zero!");
                 }
 
-                if (!conditionService.isForceCloseCondition() && spreadVerification.compareTo(activePosition.getExitTarget()) > 0) {
+                if (conditionService.isBlackoutCondition(longExchange) || conditionService.isBlackoutCondition(shortExchange)) {
+                    LOGGER.warn("Cannot exit position on one or more exchanges due to user configured blackout");
+                } else if (!conditionService.isForceCloseCondition() && spreadVerification.compareTo(activePosition.getExitTarget()) > 0) {
                     LOGGER.debug("Not enough liquidity to execute both trades profitably!");
                 } else {
                     if (conditionService.isForceCloseCondition()) {

--- a/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
@@ -1,23 +1,50 @@
 package com.r307.arbitrader.service;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
-import static com.r307.arbitrader.service.ConditionService.EXIT_WHEN_IDLE;
-import static com.r307.arbitrader.service.ConditionService.FORCE_CLOSE;
+import static com.r307.arbitrader.service.ConditionService.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class ConditionServiceTest {
+    private static final String TEST_EXCHANGE_NAME = "Test Exchange";
+
+    @Mock
+    private Exchange exchange;
+
+    @Mock
+    private ExchangeSpecification exchangeSpecification;
+
     private ConditionService conditionService;
 
     @Before
     public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(exchange.getExchangeSpecification()).thenReturn(exchangeSpecification);
+        when(exchangeSpecification.getExchangeName()).thenReturn(TEST_EXCHANGE_NAME);
+
         conditionService = new ConditionService();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        FileUtils.deleteQuietly(new File(BLACKOUT));
     }
 
     @Test
@@ -83,5 +110,93 @@ public class ConditionServiceTest {
         assertTrue(conditionService.isExitWhenIdleCondition());
 
         FileUtils.deleteQuietly(exitWhenIdle);
+    }
+
+    @Test
+    public void testNoFileBlackoutCondition() {
+        File blackoutFile = new File(BLACKOUT);
+
+        assertFalse(blackoutFile.exists());
+        assertFalse(conditionService.isBlackoutCondition(exchange));
+    }
+
+    @Test
+    public void testFutureBlackoutBlackoutCondition() throws IOException {
+        File blackoutFile = new File(BLACKOUT);
+        PrintWriter writer = new PrintWriter(new FileOutputStream(blackoutFile));
+
+        // blackout occurs in the future
+        ZonedDateTime blackoutStart = ZonedDateTime.now().plusHours(1L);
+        ZonedDateTime blackoutEnd = ZonedDateTime.now().plusHours(2L);
+
+        writer.println(String.format("%s,%s,%s",
+            TEST_EXCHANGE_NAME,
+            blackoutStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+            blackoutEnd.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)));
+        writer.close();
+
+        assertFalse(conditionService.isBlackoutCondition(exchange));
+
+        FileUtils.deleteQuietly(blackoutFile);
+    }
+
+    @Test
+    public void testPastBlackoutBlackoutCondition() throws IOException {
+        File blackoutFile = new File(BLACKOUT);
+        PrintWriter writer = new PrintWriter(new FileOutputStream(blackoutFile));
+
+        // blackout occurs in the past
+        ZonedDateTime blackoutStart = ZonedDateTime.now().minusHours(2L);
+        ZonedDateTime blackoutEnd = ZonedDateTime.now().minusHours(1L);
+
+        writer.println(String.format("%s,%s,%s",
+            TEST_EXCHANGE_NAME,
+            blackoutStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+            blackoutEnd.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)));
+        writer.close();
+
+        assertFalse(conditionService.isBlackoutCondition(exchange));
+
+        FileUtils.deleteQuietly(blackoutFile);
+    }
+
+    @Test
+    public void testCurrentBlackoutBlackoutCondition() throws IOException {
+        File blackoutFile = new File(BLACKOUT);
+        PrintWriter writer = new PrintWriter(new FileOutputStream(blackoutFile));
+
+        // blackout is in progress
+        ZonedDateTime blackoutStart = ZonedDateTime.now().minusHours(1L);
+        ZonedDateTime blackoutEnd = ZonedDateTime.now().plusHours(1L);
+
+        writer.println(String.format("%s,%s,%s",
+            TEST_EXCHANGE_NAME,
+            blackoutStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+            blackoutEnd.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)));
+        writer.close();
+
+        assertTrue(conditionService.isBlackoutCondition(exchange));
+
+        FileUtils.deleteQuietly(blackoutFile);
+    }
+
+    @Test
+    public void testCurrentBlackoutForOtherExchangeBlackoutCondition() throws IOException {
+        File blackoutFile = new File(BLACKOUT);
+        PrintWriter writer = new PrintWriter(new FileOutputStream(blackoutFile));
+
+        // blackout is in progress
+        ZonedDateTime blackoutStart = ZonedDateTime.now().minusHours(1L);
+        ZonedDateTime blackoutEnd = ZonedDateTime.now().plusHours(1L);
+
+        writer.println(String.format("%s,%s,%s",
+            "Other Exchange",
+            blackoutStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+            blackoutEnd.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)));
+        writer.close();
+
+        assertFalse(conditionService.isBlackoutCondition(exchange));
+
+        FileUtils.deleteQuietly(blackoutFile);
     }
 }


### PR DESCRIPTION
Allows a user to create a file named 'blackout' in the current working directory with "extended" ISO-8601 dates indicating that the bot should not trade during the specified times. Each line of the file should look like this:

```
Cool Coins,2011-12-03T10:15:30+01:00,2011-12-03T12:15:30+01:00
```

The above indicates that for the exchange "Cool Coins" from 10:15 to 12:15 on Dec 3, 2011 we should not trade. The file can have as many lines as you wish and may safely be changed or deleted while the bot is running. Each time the bot wants to trade, it will attempt to read the file and check whether the current time is within any of the specified blackout windows.