### PR TITLE
fee override configuration option

### DIFF
--- a/src/main/java/com/r307/arbitrader/config/ExchangeConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/ExchangeConfiguration.java
@@ -22,6 +22,7 @@ public class ExchangeConfiguration {
     private Boolean margin;
     private List<CurrencyPair> marginExclude = new ArrayList<>();
     private BigDecimal fee;
+    private BigDecimal feeOverride;
     private Currency homeCurrency = Currency.USD;
     private Map<String, Integer> ticker = new HashMap<>();
 
@@ -119,6 +120,14 @@ public class ExchangeConfiguration {
 
     public void setFee(BigDecimal fee) {
         this.fee = fee;
+    }
+
+    public BigDecimal getFeeOverride() {
+        return feeOverride;
+    }
+
+    public void setFeeOverride(BigDecimal feeOverride) {
+        this.feeOverride = feeOverride;
     }
 
     public Currency getHomeCurrency() {

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -642,6 +642,18 @@ public class TradingService {
             return cachedFee;
         }
 
+        // if an explicit override is configured, default to that
+        if (exchangeService.getExchangeMetadata(exchange).getFeeOverride() != null) {
+            BigDecimal fee = exchangeService.getExchangeMetadata(exchange).getFeeOverride();
+            feeCache.setCachedFee(exchange, currencyPair, fee);
+
+            LOGGER.trace("Using explicitly configured fee override of {} for {}",
+                fee,
+                exchange.getExchangeSpecification().getExchangeName());
+
+            return fee;
+        }
+
         try {
             Map<CurrencyPair, Fee> fees = exchange.getAccountService().getDynamicTradingFees();
 
@@ -651,6 +663,9 @@ public class TradingService {
                 // We're going to cache this value. Fees don't change all that often and we don't want to use up
                 // our allowance of API calls just checking the fees.
                 feeCache.setCachedFee(exchange, currencyPair, fee);
+
+                LOGGER.trace("Using dynamic maker fee for {}",
+                    exchange.getExchangeSpecification().getExchangeName());
 
                 return fee;
             }


### PR DESCRIPTION
New `feeOverride` option in `application.yaml` that forces Arbitrader to use the fee amount that you provided instead of what XChange provides. I've been finding that a lot of exchanges have maker and taker reversed or just not configured correctly. This will let you easily correct those kinds of problems.

Fixes #125 