### PR TITLE
optional timeout for how long an open position may remain open

### DIFF
--- a/application.example.yaml
+++ b/application.example.yaml
@@ -40,6 +40,11 @@ trading:
   tradeBlacklist:
     - Quoine:Kraken:ETH/USD
 
+  # (Optional)
+  # Set a time limit for open positions. If a position is open longer than the time limit it will be closed regardless
+  # of whether it will turn a profit or not. The value of this property is expressed in minutes. 86400 equals 1 day.
+  tradeTimeout: 86400
+
   # Connection information for each exchange goes in this list.
   #
   # To add a new exchange or remove one that you don't use, either add or remove the configuration from this list.

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
 
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+
     compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '4.4.2'
     compile group: 'org.knowm.xchange', name: 'xchange-kraken', version: '4.4.2'
     compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '4.4.2'
@@ -44,8 +46,6 @@ dependencies {
     compile group: 'org.knowm.xchange', name: 'xchange-gemini', version: '4.4.2'
     compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '4.4.2'
     compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '4.4.2'
-
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
     compile group: 'com.github.seratch', name: 'jslack', version: '1.1.6'
     compile group: 'javax.websocket', name: 'javax.websocket-api', version: '1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.7.1-SNAPSHOT'
+version '0.8.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '4.4.2'
     compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '4.4.2'
 
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+
     compile group: 'com.github.seratch', name: 'jslack', version: '1.1.6'
     compile group: 'javax.websocket', name: 'javax.websocket-api', version: '1.1'
     compile group: 'org.glassfish.tyrus.bundles', name: 'tyrus-standalone-client', version: '1.16'

--- a/src/main/java/com/r307/arbitrader/config/JsonConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/JsonConfiguration.java
@@ -1,0 +1,22 @@
+package com.r307.arbitrader.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonConfiguration {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.findAndRegisterModules();
+        objectMapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_WITH_ZONE_ID, true);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/TradingConfiguration.java
@@ -18,6 +18,7 @@ public class TradingConfiguration {
     private BigDecimal fixedExposure;
     private List<ExchangeConfiguration> exchanges = new ArrayList<>();
     private List<String> tradeBlacklist = new ArrayList<>();
+    private Long tradeTimeout;
 
     public BigDecimal getEntrySpread() {
         return entrySpread;
@@ -57,5 +58,13 @@ public class TradingConfiguration {
 
     public void setTradeBlacklist(List<String> tradeBlacklist) {
         this.tradeBlacklist = tradeBlacklist;
+    }
+
+    public Long getTradeTimeout() {
+        return tradeTimeout;
+    }
+
+    public void setTradeTimeout(Long tradeTimeout) {
+        this.tradeTimeout = tradeTimeout;
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -36,7 +36,6 @@ import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
@@ -376,7 +375,7 @@ public class TradingService {
                 && spreadIn.compareTo(tradingConfiguration.getEntrySpread()) <= 0
                 && missedTrades.containsKey(tradeCombination)) {
 
-                LOGGER.info("{} has exited entry threshold: {}", tradeCombination, spreadIn);
+                LOGGER.debug("{} has exited entry threshold: {}", tradeCombination, spreadIn);
 
                 missedTrades.remove(tradeCombination);
             }
@@ -388,7 +387,7 @@ public class TradingService {
                         || !activePosition.getShortTrade().getExchange().equals(shortExchange.getExchangeSpecification().getExchangeName())) {
 
                         if (!missedTrades.containsKey(tradeCombination)) {
-                            LOGGER.info("{} has entered entry threshold: {}", tradeCombination, spreadIn);
+                            LOGGER.debug("{} has entered entry threshold: {}", tradeCombination, spreadIn);
 
                             missedTrades.put(tradeCombination, spreadIn);
                         }
@@ -1023,7 +1022,7 @@ public class TradingService {
             .divide(step, RoundingMode.HALF_EVEN)
             .setScale(0, RoundingMode.HALF_EVEN)
             .multiply(step)
-            .setScale(input.scale(), RoundingMode.HALF_EVEN);
+            .setScale(step.scale(), RoundingMode.HALF_EVEN);
 
         LOGGER.info("result = {}", result);
 
@@ -1035,6 +1034,6 @@ public class TradingService {
             return false;
         }
 
-        return activePosition.getEntryTime().plusHours(tradingConfiguration.getTradeTimeout()).isAfter(OffsetDateTime.now());
+        return activePosition.getEntryTime().plusHours(tradingConfiguration.getTradeTimeout()).isBefore(OffsetDateTime.now());
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -562,6 +562,11 @@ public class TradingService {
                     LOGGER.debug("Not enough liquidity to execute both trades profitably!");
                 } else {
                     if (isTradeExpired()) {
+                        if (spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
+                            LOGGER.debug("Not exiting for timeout because it would immediately re-enter");
+                            return;
+                        }
+
                         LOGGER.warn("***** TIMEOUT EXIT *****");
                     } else if (conditionService.isForceCloseCondition()) {
                         LOGGER.warn("***** FORCED EXIT *****");

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -561,19 +561,16 @@ public class TradingService {
 
                 if (conditionService.isBlackoutCondition(longExchange) || conditionService.isBlackoutCondition(shortExchange)) {
                     LOGGER.warn("Cannot exit position on one or more exchanges due to user configured blackout");
-                } else if (!conditionService.isForceCloseCondition() && spreadVerification.compareTo(activePosition.getExitTarget()) > 0) {
+                } else if (isTradeExpired() && spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
+                    if (!timeoutExitWarning) {
+                        LOGGER.warn("Timeout exit triggered");
+                        LOGGER.warn("Cannot exit now because spread would cause immediate reentry");
+                        timeoutExitWarning = true;
+                    }
+                } else if (!isTradeExpired() && !conditionService.isForceCloseCondition() && spreadVerification.compareTo(activePosition.getExitTarget()) > 0) {
                     LOGGER.debug("Not enough liquidity to execute both trades profitably!");
                 } else {
                     if (isTradeExpired()) {
-                        if (spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
-                            if (!timeoutExitWarning) {
-                                LOGGER.warn("Timeout exit triggered");
-                                LOGGER.warn("Cannot exit now because spread would cause immediate reentry");
-                                timeoutExitWarning = true;
-                            }
-                            return;
-                        }
-
                         LOGGER.warn("***** TIMEOUT EXIT *****");
                         timeoutExitWarning = false;
                     } else if (conditionService.isForceCloseCondition()) {

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -224,7 +224,7 @@ public class TradingService {
         }
 
         if (tradingConfiguration.getTradeTimeout() != null) {
-            LOGGER.info("Using trade timeout of {} minutes", tradingConfiguration.getTradeTimeout());
+            LOGGER.info("Using trade timeout of {} hours", tradingConfiguration.getTradeTimeout());
         }
 
         // load active trades from file, if there is one

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -83,6 +83,7 @@ public class TradingService {
     private Map<String, BigDecimal> maxSpread = new HashMap<>();
     private Map<TradeCombination, BigDecimal> missedTrades = new HashMap<>();
     private boolean bailOut = false;
+    private boolean timeoutExitWarning = false;
     private ActivePosition activePosition = null;
 
     public TradingService(
@@ -565,11 +566,16 @@ public class TradingService {
                 } else {
                     if (isTradeExpired()) {
                         if (spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
-                            LOGGER.debug("Not exiting for timeout because it would immediately re-enter");
+                            if (!timeoutExitWarning) {
+                                LOGGER.warn("Timeout exit triggered");
+                                LOGGER.warn("Cannot exit now because spread would cause immediate reentry");
+                                timeoutExitWarning = true;
+                            }
                             return;
                         }
 
                         LOGGER.warn("***** TIMEOUT EXIT *****");
+                        timeoutExitWarning = false;
                     } else if (conditionService.isForceCloseCondition()) {
                         LOGGER.warn("***** FORCED EXIT *****");
                     } else {

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -497,6 +497,7 @@ public class TradingService {
 
                     try {
                         activePosition = new ActivePosition();
+                        activePosition.setEntryTime(OffsetDateTime.now());
                         activePosition.setCurrencyPair(currencyPair);
                         activePosition.setExitTarget(exitTarget);
                         activePosition.setEntryBalance(totalBalance);
@@ -1013,10 +1014,10 @@ public class TradingService {
     }
 
     private boolean isTradeExpired() {
-        if (tradingConfiguration.getTradeTimeout() == null || activePosition == null) {
+        if (tradingConfiguration.getTradeTimeout() == null || activePosition == null || activePosition.getEntryTime() == null) {
             return false;
         }
 
-        return activePosition.getEntryTime().plusMinutes(tradingConfiguration.getTradeTimeout()).isAfter(OffsetDateTime.now());
+        return activePosition.getEntryTime().plusHours(tradingConfiguration.getTradeTimeout()).isAfter(OffsetDateTime.now());
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -1017,11 +1017,17 @@ public class TradingService {
      * set the precision on round() to zero. You can do it with setScale() and it will implicitly do the rounding.
      */
     static BigDecimal roundByStep(BigDecimal input, BigDecimal step) {
-        return input
+        LOGGER.info("input = {} step = {}", input, step);
+
+        BigDecimal result = input
             .divide(step, RoundingMode.HALF_EVEN)
             .setScale(0, RoundingMode.HALF_EVEN)
             .multiply(step)
             .setScale(input.scale(), RoundingMode.HALF_EVEN);
+
+        LOGGER.info("result = {}", result);
+
+        return result;
     }
 
     private boolean isTradeExpired() {

--- a/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
+++ b/src/main/java/com/r307/arbitrader/service/model/ActivePosition.java
@@ -5,6 +5,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
@@ -14,6 +15,7 @@ public class ActivePosition {
     private CurrencyPair currencyPair;
     private BigDecimal exitTarget;
     private BigDecimal entryBalance; // USD balance of both exchanges summed when the trades were first opened
+    private OffsetDateTime entryTime;
 
     public Trade getLongTrade() {
         return longTrade;
@@ -47,6 +49,14 @@ public class ActivePosition {
         this.entryBalance = entryBalance;
     }
 
+    public OffsetDateTime getEntryTime() {
+        return entryTime;
+    }
+
+    public void setEntryTime(OffsetDateTime entryTime) {
+        this.entryTime = entryTime;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -56,12 +66,13 @@ public class ActivePosition {
             Objects.equals(getShortTrade(), that.getShortTrade()) &&
             Objects.equals(getCurrencyPair(), that.getCurrencyPair()) &&
             Objects.equals(getExitTarget(), that.getExitTarget()) &&
-            Objects.equals(getEntryBalance(), that.getEntryBalance());
+            Objects.equals(getEntryBalance(), that.getEntryBalance()) &&
+            Objects.equals(getEntryTime(), that.getEntryTime());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getLongTrade(), getShortTrade(), getCurrencyPair(), getExitTarget(), getEntryBalance());
+        return Objects.hash(getLongTrade(), getShortTrade(), getCurrencyPair(), getExitTarget(), getEntryBalance(), getEntryTime());
     }
 
     @Override
@@ -72,6 +83,7 @@ public class ActivePosition {
             ", currencyPair=" + currencyPair +
             ", exitTarget=" + exitTarget +
             ", entryBalance=" + entryBalance +
+            ", entryTime=" + entryTime +
             '}';
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,3 +3,7 @@ logging:
     si:
       mazi:
         rescu: ERROR
+spring:
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false

--- a/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
+++ b/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
@@ -85,17 +85,17 @@ public class ExchangeBuilder {
         currencyPairs.forEach(currencyPair ->
             tickers.add(new Ticker.Builder()
                 .currencyPair(currencyPair)
-                .open(new BigDecimal(1000.000))
-                .last(new BigDecimal(1001.000))
-                .bid(new BigDecimal(1001.000))
-                .ask(new BigDecimal(1002.000))
-                .high(new BigDecimal(1005.00))
-                .low(new BigDecimal(1000.00))
-                .vwap(new BigDecimal(1000.50))
-                .volume(new BigDecimal(500000.00))
-                .quoteVolume(new BigDecimal(600000.00))
-                .bidSize(new BigDecimal(400.00))
-                .askSize(new BigDecimal(600.00))
+                .open(new BigDecimal("1000.000"))
+                .last(new BigDecimal("1001.000"))
+                .bid(new BigDecimal("1001.000"))
+                .ask(new BigDecimal("1002.000"))
+                .high(new BigDecimal("1005.00"))
+                .low(new BigDecimal("1000.00"))
+                .vwap(new BigDecimal("1000.50"))
+                .volume(new BigDecimal("500000.00"))
+                .quoteVolume(new BigDecimal("600000.00"))
+                .bidSize(new BigDecimal("400.00"))
+                .askSize(new BigDecimal("600.00"))
                 .build())
         );
 
@@ -116,9 +116,9 @@ public class ExchangeBuilder {
 
     public ExchangeBuilder withExchangeMetaData() {
         CurrencyPairMetaData currencyPairMetaData = new CurrencyPairMetaData(
-            new BigDecimal(0.0020),
-            new BigDecimal(0.0010),
-            new BigDecimal(1000.00000000),
+            new BigDecimal("0.0020"),
+            new BigDecimal("0.0010"),
+            new BigDecimal("1000.00000000"),
             BTC_SCALE,
             null,
             null);
@@ -153,8 +153,8 @@ public class ExchangeBuilder {
             currencyPair,
             UUID.randomUUID().toString(),
             new Date(),
-            new BigDecimal(100.0000)
-                .add(new BigDecimal(0.001))
+            new BigDecimal("100.0000")
+                .add(new BigDecimal("0.001"))
                 .setScale(BTC_SCALE, RoundingMode.HALF_EVEN));
 
         when(tradeService.getOrder(eq("orderId"))).thenReturn(Collections.singleton(order));
@@ -249,7 +249,7 @@ public class ExchangeBuilder {
                 currencyPair,
                 UUID.randomUUID().toString(),
                 new Date(),
-                new BigDecimal(100.0000)
+                new BigDecimal("100.0000")
                     .add(new BigDecimal(i * 0.001))
                     .setScale(BTC_SCALE, RoundingMode.HALF_EVEN)));
         }

--- a/src/test/java/com/r307/arbitrader/service/ExchangeFeeCacheTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ExchangeFeeCacheTest.java
@@ -40,11 +40,11 @@ public class ExchangeFeeCacheTest {
 
     @Test
     public void testSetAndGet() {
-        exchangeFeeCache.setCachedFee(exchange, currencyPair, new BigDecimal(0.0025));
-        exchangeFeeCache.setCachedFee(exchange, CurrencyPair.BTC_USD, new BigDecimal(0.0010));
-        exchangeFeeCache.setCachedFee(exchange, CurrencyPair.ETH_USD, new BigDecimal(0.0030));
+        exchangeFeeCache.setCachedFee(exchange, currencyPair, new BigDecimal("0.0025"));
+        exchangeFeeCache.setCachedFee(exchange, CurrencyPair.BTC_USD, new BigDecimal("0.0010"));
+        exchangeFeeCache.setCachedFee(exchange, CurrencyPair.ETH_USD, new BigDecimal("0.0030"));
 
-        assertEquals(new BigDecimal(0.0025), exchangeFeeCache.getCachedFee(exchange, currencyPair));
+        assertEquals(new BigDecimal("0.0025"), exchangeFeeCache.getCachedFee(exchange, currencyPair));
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -345,32 +345,32 @@ public class TradingServiceTest {
     }
 
     @Test
-    public void testRoundByDecimals54() {
-        BigDecimal input = new BigDecimal("0.054");
+    public void testRoundByDecimals34() {
+        BigDecimal input = new BigDecimal("0.034379584992664");
         BigDecimal step = new BigDecimal("0.01");
 
         BigDecimal result = TradingService.roundByStep(input, step);
 
-        assertEquals(new BigDecimal("0.050"), result);
+        assertEquals(new BigDecimal("0.03"), result);
     }
 
     @Test
-    public void testRoundByDecimals55() {
-        BigDecimal input = new BigDecimal("0.055");
+    public void testRoundByDecimals35() {
+        BigDecimal input = new BigDecimal("0.035379584992664");
         BigDecimal step = new BigDecimal("0.01");
 
         BigDecimal result = TradingService.roundByStep(input, step);
 
-        assertEquals(new BigDecimal("0.060"), result);
+        assertEquals(new BigDecimal("0.04"), result);
     }
 
     @Test
-    public void testRoundByDecimals56() {
-        BigDecimal input = new BigDecimal("0.056");
+    public void testRoundByDecimals36() {
+        BigDecimal input = new BigDecimal("0.036379584992664");
         BigDecimal step = new BigDecimal("0.01");
 
         BigDecimal result = TradingService.roundByStep(input, step);
 
-        assertEquals(new BigDecimal("0.060"), result);
+        assertEquals(new BigDecimal("0.04"), result);
     }
 }

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -343,4 +343,34 @@ public class TradingServiceTest {
 
         assertEquals(new BigDecimal("80.00"), result);
     }
+
+    @Test
+    public void testRoundByDecimals54() {
+        BigDecimal input = new BigDecimal("0.054");
+        BigDecimal step = new BigDecimal("0.01");
+
+        BigDecimal result = TradingService.roundByStep(input, step);
+
+        assertEquals(new BigDecimal("0.050"), result);
+    }
+
+    @Test
+    public void testRoundByDecimals55() {
+        BigDecimal input = new BigDecimal("0.055");
+        BigDecimal step = new BigDecimal("0.01");
+
+        BigDecimal result = TradingService.roundByStep(input, step);
+
+        assertEquals(new BigDecimal("0.060"), result);
+    }
+
+    @Test
+    public void testRoundByDecimals56() {
+        BigDecimal input = new BigDecimal("0.056");
+        BigDecimal step = new BigDecimal("0.01");
+
+        BigDecimal result = TradingService.roundByStep(input, step);
+
+        assertEquals(new BigDecimal("0.060"), result);
+    }
 }

--- a/src/test/java/com/r307/arbitrader/service/model/ActivePositionTest.java
+++ b/src/test/java/com/r307/arbitrader/service/model/ActivePositionTest.java
@@ -2,6 +2,7 @@ package com.r307.arbitrader.service.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.r307.arbitrader.ExchangeBuilder;
+import com.r307.arbitrader.config.JsonConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -12,42 +13,46 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 import static org.junit.Assert.assertEquals;
 
 public class ActivePositionTest {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
+    private ObjectMapper objectMapper;
     private CurrencyPair currencyPair = CurrencyPair.BTC_USD;
-    private BigDecimal exitTarget = new BigDecimal(0.003);
+    private BigDecimal exitTarget = new BigDecimal("0.003");
     private Exchange longExchange = null;
     private Exchange shortExchange = null;
-    private BigDecimal longVolume = new BigDecimal(1000.00);
-    private BigDecimal shortVolume = new BigDecimal(1000.00);
-    private BigDecimal longLimitPrice = new BigDecimal(5000.00);
-    private BigDecimal shortLimitPrice = new BigDecimal(5000.00);
-    private ActivePosition activePosition;
+    private BigDecimal longVolume = new BigDecimal("1000.00");
+    private BigDecimal shortVolume = new BigDecimal("1000.00");
+    private BigDecimal longLimitPrice = new BigDecimal("5000.00");
+    private BigDecimal shortLimitPrice = new BigDecimal("5000.00");
 
     @Before
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
 
+        objectMapper = new JsonConfiguration().objectMapper();
+
         longExchange = new ExchangeBuilder("Long", CurrencyPair.BTC_USD)
             .withTradeService()
             .withOrderBook(100, 100)
-            .withBalance(Currency.USD, new BigDecimal(100.00).setScale(USD_SCALE, RoundingMode.HALF_EVEN))
+            .withBalance(Currency.USD, new BigDecimal("100.00").setScale(USD_SCALE, RoundingMode.HALF_EVEN))
             .build();
         shortExchange = new ExchangeBuilder("Short", CurrencyPair.BTC_USD)
-            .withBalance(Currency.USD, new BigDecimal(500.00).setScale(USD_SCALE, RoundingMode.HALF_EVEN))
+            .withBalance(Currency.USD, new BigDecimal("500.00").setScale(USD_SCALE, RoundingMode.HALF_EVEN))
             .build();
     }
 
     @Test
     public void testSerialization() throws IOException{
-        activePosition = new ActivePosition();
+        ActivePosition activePosition = new ActivePosition();
+
+        activePosition.setEntryTime(OffsetDateTime.now());
+        activePosition.setEntryBalance(new BigDecimal("1337.00"));
         activePosition.setCurrencyPair(currencyPair);
         activePosition.setExitTarget(exitTarget);
         activePosition.getLongTrade().setOrderId(UUID.randomUUID().toString());
@@ -59,9 +64,9 @@ public class ActivePositionTest {
         activePosition.getShortTrade().setVolume(shortVolume);
         activePosition.getShortTrade().setEntry(shortLimitPrice);
 
-        String json = OBJECT_MAPPER.writeValueAsString(activePosition);
+        String json = objectMapper.writeValueAsString(activePosition);
 
-        ActivePosition deserialized = OBJECT_MAPPER.readValue(json.getBytes(Charset.forName("utf-8")), ActivePosition.class);
+        ActivePosition deserialized = objectMapper.readValue(json.getBytes(StandardCharsets.UTF_8), ActivePosition.class);
 
         assertEquals(activePosition, deserialized);
     }


### PR DESCRIPTION
This is a good option to limit the effect of ongoing fees from the exchange where you have your short position. If you leave that position open long enough it can easily eat up all the profit from your trades, and currently Arbitrader is not capable of tracking those costs.

Closes #30 