### PR TITLE
force a scale with more decimals for spread computation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.7.0-SNAPSHOT'
+version '0.7.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -826,7 +826,10 @@ public class TradingService {
     }
 
     private BigDecimal computeSpread(BigDecimal longPrice, BigDecimal shortPrice) {
-        return (shortPrice.subtract(longPrice)).divide(longPrice, RoundingMode.HALF_EVEN);
+        BigDecimal scaledLongPrice = longPrice.setScale(BTC_SCALE, RoundingMode.HALF_EVEN);
+        BigDecimal scaledShortPrice = shortPrice.setScale(BTC_SCALE, RoundingMode.HALF_EVEN);
+
+        return (scaledShortPrice.subtract(scaledLongPrice)).divide(scaledLongPrice, RoundingMode.HALF_EVEN);
     }
 
     BigDecimal getVolumeForOrder(Exchange exchange, CurrencyPair currencyPair, String orderId, BigDecimal defaultVolume) {


### PR DESCRIPTION
Some exchanges return prices with very few decimal places which causes the spread calculation to toggle between 0.00 and 0.01. When the entry threshold is a number with more decimals like 0.008 the lack of granularity makes the bot thrash between wanting to enter and wanting to exit. This change will force the prices to have more decimal places during spread computation and give us more granular spread values to work with.