### PR TITLE
isolate stray IOEs to avoid jumping out of the loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 out/
 
 *.iml
+.env
 /application.yaml
 /arbitrader-state.json
 /blackout

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.8.1-SNAPSHOT'
+version '0.8.2-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -445,6 +445,9 @@ public class TradingService {
                 BigDecimal longStepSize = longExchange.getExchangeMetaData().getCurrencyPairs().getOrDefault(exchangeService.convertExchangePair(longExchange, currencyPair), NULL_CURRENCY_PAIR_METADATA).getAmountStepSize();
                 BigDecimal shortStepSize = shortExchange.getExchangeMetaData().getCurrencyPairs().getOrDefault(exchangeService.convertExchangePair(shortExchange, currencyPair), NULL_CURRENCY_PAIR_METADATA).getAmountStepSize();
 
+                LOGGER.info("Long exchange volume before rounding: {}", longVolume);
+                LOGGER.info("Short exchange volume before rounding: {}", shortVolume);
+
                 if (longStepSize != null) {
                     longVolume = roundByStep(longVolume, longStepSize);
                 }
@@ -452,6 +455,9 @@ public class TradingService {
                 if (shortStepSize != null) {
                     shortVolume = roundByStep(shortVolume, shortStepSize);
                 }
+
+                LOGGER.info("Long exchange volume after rounding: {}", longVolume);
+                LOGGER.info("Short exchange volume after rounding: {}", shortVolume);
 
                 BigDecimal longLimitPrice;
                 BigDecimal shortLimitPrice;

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -439,6 +439,10 @@ public class TradingService {
                 int longScale = longExchange.getExchangeMetaData().getCurrencyPairs().compute(exchangeService.convertExchangePair(longExchange, currencyPair), this::getScale).getPriceScale();
                 int shortScale = longExchange.getExchangeMetaData().getCurrencyPairs().compute(exchangeService.convertExchangePair(shortExchange, currencyPair), this::getScale).getPriceScale();
 
+                LOGGER.info("Max exposure: {}", maxExposure);
+                LOGGER.info("Long ticker ASK: {}", longTicker.getAsk());
+                LOGGER.info("Short ticker BID: {}", shortTicker.getBid());
+
                 BigDecimal longVolume = maxExposure.divide(longTicker.getAsk(), longScale, RoundingMode.HALF_EVEN);
                 BigDecimal shortVolume = maxExposure.divide(shortTicker.getBid(), shortScale, RoundingMode.HALF_EVEN);
 


### PR DESCRIPTION
I got `SocketTimeoutException`s fetching the `OpenOrders` while waiting for an order to fill and it jumped me out of the loop, tried to enter another trade and died because there wasn't enough available balance (one of the trades hadn't been closed). This solution is verbose but won't allow a broken connection from the long exchange to exit the loop or skip checking the short exchange.