### PR TITLE
Fix NPE on XData (v5.0.2) for Gemini Streaming Exchange when args is empy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.0'
     compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.0'
     compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-gemini', version: '5.0.0'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-gemini', version: '5.0.3'
     compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.0'
     compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.0'
 

--- a/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
+++ b/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
@@ -1,8 +1,10 @@
 package com.r307.arbitrader.service.ticker;
 
 import com.r307.arbitrader.service.ErrorCollectorService;
+import com.r307.arbitrader.service.ExchangeService;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
+import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -24,10 +26,12 @@ public class StreamingTickerStrategy implements TickerStrategy {
     private final List<Disposable> subscriptions = new ArrayList<>();
     private final Map<StreamingExchange, Map<CurrencyPair, Ticker>> tickers = new HashMap<>();
     private final ErrorCollectorService errorCollectorService;
+    private final ExchangeService exchangeService;
 
     @Inject
-    public StreamingTickerStrategy(ErrorCollectorService errorCollectorService) {
+    public StreamingTickerStrategy(ErrorCollectorService errorCollectorService, ExchangeService exchangeService) {
         this.errorCollectorService = errorCollectorService;
+        this.exchangeService = exchangeService;
     }
 
     @Override
@@ -62,21 +66,32 @@ public class StreamingTickerStrategy implements TickerStrategy {
     private List<Disposable> subscribeAll(StreamingExchange exchange, List<CurrencyPair> currencyPairs) {
         return currencyPairs
             .stream()
-            .map(pair -> exchange.getStreamingMarketDataService().getTicker(pair).subscribe(
-                ticker -> {
-                    tickers.computeIfAbsent(exchange, e -> new HashMap<>());
-                    tickers.get(exchange).put(pair, ticker);
+            .map(pair -> {
+                // TODO: Temp fix while https://github.com/knowm/XChange/pull/3761 is not merged and released
+                final Observable<Ticker> tickerObservable;
+                final String exchangeName = exchange.getExchangeSpecification().getExchangeName();
+                if (exchangeName.contains("Gemini")) {
+                    tickerObservable = exchange.getStreamingMarketDataService().getTicker(exchangeService.convertExchangePair(exchange, pair), 10);
+                }
+                else {
+                    tickerObservable = exchange.getStreamingMarketDataService().getTicker(exchangeService.convertExchangePair(exchange, pair));
+                }
+                return tickerObservable.subscribe(
+                    ticker -> {
+                        tickers.computeIfAbsent(exchange, e -> new HashMap<>());
+                        tickers.get(exchange).put(pair, ticker);
 
-                    LOGGER.debug("Received ticker: {} {} {}/{}",
-                        exchange.getExchangeSpecification().getExchangeName(),
-                        ticker.getCurrencyPair(),
-                        ticker.getBid(),
-                        ticker.getAsk());
-                },
-                throwable -> {
-                    errorCollectorService.collect(exchange, throwable);
-                    LOGGER.debug("Unexpected checked exception: " + throwable.getMessage(), throwable);
-                }))
+                        LOGGER.debug("Received ticker: {} {} {}/{}",
+                            exchangeName,
+                            ticker.getCurrencyPair(),
+                            ticker.getBid(),
+                            ticker.getAsk());
+                    },
+                    throwable -> {
+                        errorCollectorService.collect(exchange, throwable);
+                        LOGGER.debug("Unexpected checked exception: {}", throwable.getMessage(), throwable);
+                    });
+            })
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
+++ b/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
@@ -4,6 +4,7 @@ import com.r307.arbitrader.service.ErrorCollectorService;
 import com.r307.arbitrader.service.ExchangeService;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
+import info.bitrich.xchangestream.gemini.GeminiStreamingExchange;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import org.knowm.xchange.Exchange;
@@ -69,8 +70,7 @@ public class StreamingTickerStrategy implements TickerStrategy {
             .map(pair -> {
                 // TODO: Temp fix while https://github.com/knowm/XChange/pull/3761 is not merged and released
                 final Observable<Ticker> tickerObservable;
-                final String exchangeName = exchange.getExchangeSpecification().getExchangeName();
-                if (exchangeName.contains("Gemini")) {
+                if (exchange instanceof GeminiStreamingExchange) {
                     tickerObservable = exchange.getStreamingMarketDataService().getTicker(exchangeService.convertExchangePair(exchange, pair), 10);
                 }
                 else {
@@ -82,7 +82,7 @@ public class StreamingTickerStrategy implements TickerStrategy {
                         tickers.get(exchange).put(pair, ticker);
 
                         LOGGER.debug("Received ticker: {} {} {}/{}",
-                            exchangeName,
+                            exchange.getExchangeSpecification().getExchangeName(),
                             ticker.getCurrencyPair(),
                             ticker.getBid(),
                             ticker.getAsk());

--- a/src/test/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategyTest.java
@@ -2,6 +2,7 @@ package com.r307.arbitrader.service.ticker;
 
 import com.r307.arbitrader.ExchangeBuilder;
 import com.r307.arbitrader.service.ErrorCollectorService;
+import com.r307.arbitrader.service.ExchangeService;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -17,6 +18,8 @@ import static org.junit.Assert.assertTrue;
 public class StreamingTickerStrategyTest {
     @Mock
     private ErrorCollectorService errorCollectorService;
+    @Mock
+    private ExchangeService exchangeService;
 
     private StreamingTickerStrategy streamingTickerStrategy;
 
@@ -24,7 +27,7 @@ public class StreamingTickerStrategyTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        streamingTickerStrategy = new StreamingTickerStrategy(errorCollectorService);
+        streamingTickerStrategy = new StreamingTickerStrategy(errorCollectorService, exchangeService);
     }
 
     @Test


### PR DESCRIPTION
Respect the homeCurrency configuration field when using a StreamingExchange class

On the streaming class, if an exchange has the homeCurrency set in the configuration yaml file this was not taking in consideration (missing a call `to exchangeService.convertExchangePair(exchange, pair)`)

For `GeminiStreamingMarketDataService` on v5.0.2 we must pass on a value to the args parameter or it will throw a null pointer exception (I fixed it on the XChange side, please see: https://github.com/knowm/XChange/pull/3761). So as soon as the new version is released we can clean up this if else code.

On line 74 (`exchange.getStreamingMarketDataService().getTicker(exchangeService.convertExchangePair(exchange, pair), 10);`) I choose the number 10 for no special reason. Please let me know if it should be a different number and I will change it.