### PR TITLE
catch up on Spring and XChange versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.3.1.RELEASE'
-    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'info.solidsoft.pitest' version '1.5.1'
     id 'org.owasp.dependencycheck' version '5.3.2.1'
     id 'org.kordamp.gradle.stats' version '0.2.2'
@@ -37,15 +37,15 @@ dependencies {
 
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
-    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-kraken', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-gemini', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.0'
-    compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.0'
+    compile group: 'org.knowm.xchange', name: 'xchange-quoine', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-kraken', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitflyer', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-stream-coinbasepro', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-cexio', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-poloniex', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-gemini', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-bitstamp', version: '5.0.3'
+    compile group: 'org.knowm.xchange', name: 'xchange-cobinhood', version: '5.0.3'
 
     compile group: 'com.github.seratch', name: 'jslack', version: '1.1.6'
     compile group: 'javax.websocket', name: 'javax.websocket-api', version: '1.1'
@@ -59,7 +59,7 @@ dependencies {
 
 task buildDocker(type: Docker) {
     push = false
-    applicationName = jar.getBaseName()
+    applicationName = jar.getArchiveBaseName().get()
     dockerfile = file('src/main/docker/local/Dockerfile')
     tagVersion = "latest"
     tag = "scionaltera/${applicationName}"


### PR DESCRIPTION
Spring Boot to 2.3.4.RELEASE
XChange to 5.0.3

Also fixed a warning in build.gradle for a deprecated method.