### PR TITLE
GitHub packages

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,7 +30,7 @@ phases:
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
           docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://maven.pkg.github.com/scionaltera/arbitrader
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
         elif expr "${CODEBUILD_INITIATOR}" : "GitHub*" >/dev/null; then
@@ -38,14 +38,14 @@ phases:
           docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
           docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://maven.pkg.github.com/scionaltera/arbitrader
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         else
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
           docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
           docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://maven.pkg.github.com/scionaltera/arbitrader
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,8 @@ env:
   parameter-store:
     DOCKER_HUB_USERNAME: "docker-hub-username"
     DOCKER_HUB_PASSWORD: "docker-hub-password"
+    GITHUB_USERNAME: "github-username"
+    GITHUB_TOKEN:    "github-token"
 
 phases:
   install:
@@ -15,7 +17,6 @@ phases:
       - export BRANCH_TAG=`echo $CODEBUILD_SOURCE_VERSION | sed 's|/|-|g'`
       - echo Project version is ${PROJECT_VERSION}
       - echo Branch tag is ${BRANCH_TAG}
-      - docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
   build:
     commands:
       - docker build -t scionaltera/arbitrader:latest -f src/main/docker/codebuild/Dockerfile .
@@ -25,13 +26,26 @@ phases:
       - |
         if expr "${CODEBUILD_INITIATOR}" : "codepipeline*" >/dev/null; then
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION}
+          docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
+          docker push scionaltera/arbitrader:latest
+          docker push scionaltera/arbitrader:${PROJECT_VERSION}
+          docker logout
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
         elif expr "${CODEBUILD_INITIATOR}" : "GitHub*" >/dev/null; then
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+          docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
+          docker push scionaltera/arbitrader:${BRANCH_TAG}
+          docker logout
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         else
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+          docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
+          docker push scionaltera/arbitrader:${BRANCH_TAG}
+          docker logout
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,7 +30,7 @@ phases:
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
           docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://maven.pkg.github.com/scionaltera/arbitrader
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
         elif expr "${CODEBUILD_INITIATOR}" : "GitHub*" >/dev/null; then
@@ -38,14 +38,14 @@ phases:
           docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
           docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://maven.pkg.github.com/scionaltera/arbitrader
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         else
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
           docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
           docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://maven.pkg.github.com/scionaltera/arbitrader
+          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -27,14 +27,17 @@ phases:
       - echo "CodeBuild Initiator is ${CODEBUILD_INITIATOR}"
       - |
         if expr "${CODEBUILD_INITIATOR}" : "codepipeline*" >/dev/null; then
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION} ghcr.io/scionaltera/arbitrader:${PROJECT_VERSION}
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION}
+          docker tag scionaltera/arbitrader:latest ghcr.io/scionaltera/arbitrader:${PROJECT_VERSION}
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
         elif expr "${CODEBUILD_INITIATOR}" : "GitHub*" >/dev/null; then
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG} ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+          docker tag scionaltera/arbitrader:latest ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         else
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG} ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
+          docker tag scionaltera/arbitrader:latest ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,32 +20,21 @@ phases:
   build:
     commands:
       - docker build -t scionaltera/arbitrader:latest -f src/main/docker/codebuild/Dockerfile .
+      - docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
+      - docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
   post_build:
     commands:
       - echo "CodeBuild Initiator is ${CODEBUILD_INITIATOR}"
       - |
         if expr "${CODEBUILD_INITIATOR}" : "codepipeline*" >/dev/null; then
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION}
-          docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
-          docker push scionaltera/arbitrader:latest
-          docker push scionaltera/arbitrader:${PROJECT_VERSION}
-          docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${PROJECT_VERSION} ghcr.io/scionaltera/arbitrader:${PROJECT_VERSION}
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
         elif expr "${CODEBUILD_INITIATOR}" : "GitHub*" >/dev/null; then
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
-          docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
-          docker push scionaltera/arbitrader:${BRANCH_TAG}
-          docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG} ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         else
-          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
-          docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
-          docker push scionaltera/arbitrader:${BRANCH_TAG}
-          docker logout
-          docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN} https://ghcr.io
+          docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG} ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -31,14 +31,17 @@ phases:
           docker tag scionaltera/arbitrader:latest ghcr.io/scionaltera/arbitrader:${PROJECT_VERSION}
           docker push scionaltera/arbitrader:latest
           docker push scionaltera/arbitrader:${PROJECT_VERSION}
+          docker push ghcr.io/scionaltera/arbitrader:${PROJECT_VERSION}
         elif expr "${CODEBUILD_INITIATOR}" : "GitHub*" >/dev/null; then
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
           docker tag scionaltera/arbitrader:latest ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
+          docker push ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
         else
           docker tag scionaltera/arbitrader:latest scionaltera/arbitrader:${BRANCH_TAG}
           docker tag scionaltera/arbitrader:latest ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
           docker push scionaltera/arbitrader:${BRANCH_TAG}
+          docker push ghcr.io/scionaltera/arbitrader:${BRANCH_TAG}
         fi
       - printf '[{"name":"arbitrader","imageUri":"%s"}]' scionaltera/arbitrader:${PROJECT_VERSION} > imagedefinitions.json
 artifacts:

--- a/src/main/docker/codebuild/Dockerfile
+++ b/src/main/docker/codebuild/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazoncorretto:8-alpine as build
-MAINTAINER Peter Keeler <peter@r307.com>
+MAINTAINER Peter Keeler <peter@agonyengine.com>
 WORKDIR /opt/build
 COPY . /opt/build/
 RUN cd /opt/build \
@@ -8,7 +8,8 @@ RUN cd /opt/build \
 && ./gradlew --console=plain clean build -x buildDocker -x dependencyCheckAnalyze
 
 FROM amazoncorretto:8-alpine
-MAINTAINER Peter Keeler <peter@r307.com>
+MAINTAINER Peter Keeler <peter@agonyengine.com>
+LABEL org.opencontainers.image.source="https://github.com/scionaltera/arbitrader"
 EXPOSE 8080
 COPY --from=build /opt/build/build/libs/arbitrader-*.jar /opt/app/app.jar
 CMD ["/usr/bin/java", "-jar", "/opt/app/app.jar"]

--- a/src/main/docker/local/Dockerfile
+++ b/src/main/docker/local/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazoncorretto:8-alpine
-MAINTAINER Peter Keeler <peter@r307.com>
+MAINTAINER Peter Keeler <peter@agonyengine.com>
+LABEL org.opencontainers.image.source="https://github.com/scionaltera/arbitrader"
 EXPOSE 8080
 COPY arbitrader-*.jar /opt/app/app.jar
 CMD ["/usr/bin/java", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005", "-jar", "/opt/app/app.jar"]


### PR DESCRIPTION
Publish Docker images to the new [GitHub Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/) in addition to Docker Hub.

With Docker Hub's new [rate limits](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/) on pulls going into effect it may be that some users will need or want an alternative way to get containers. I wanted to try this feature out anyway, and it's cool that it's part of GitHub. It kind of brings everything back to one place.

For the time being we'll just publish the images to both places and the default Docker Compose configuration will still pull from Docker Hub. If you exhaust your pulls there you would be able to switch. At some point down the line we may choose one or the other.