### PR TITLE
Reactive way to calculate trades for tickers received via websockets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'docker'
 
 group 'com.r307'
-version '0.9.0-SNAPSHOT'
+version '0.10.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/r307/arbitrader/Utils.java
+++ b/src/main/java/com/r307/arbitrader/Utils.java
@@ -1,0 +1,12 @@
+package com.r307.arbitrader;
+
+import org.knowm.xchange.Exchange;
+
+public final class Utils {
+    // Intentionally empty
+    private Utils() {}
+
+    public static boolean isStreamingExchange(Exchange exchange) {
+        return exchange.getExchangeSpecification().getExchangeClassName().contains("Streaming");
+    }
+}

--- a/src/main/java/com/r307/arbitrader/Utils.java
+++ b/src/main/java/com/r307/arbitrader/Utils.java
@@ -1,5 +1,6 @@
 package com.r307.arbitrader;
 
+import info.bitrich.xchangestream.core.StreamingExchange;
 import org.knowm.xchange.Exchange;
 
 public final class Utils {
@@ -7,6 +8,6 @@ public final class Utils {
     private Utils() {}
 
     public static boolean isStreamingExchange(Exchange exchange) {
-        return exchange.getExchangeSpecification().getExchangeClassName().contains("Streaming");
+        return exchange instanceof StreamingExchange;
     }
 }

--- a/src/main/java/com/r307/arbitrader/config/AppConfig.java
+++ b/src/main/java/com/r307/arbitrader/config/AppConfig.java
@@ -1,0 +1,24 @@
+package com.r307.arbitrader.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        // Open to discussion
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(5);
+        executor.setThreadNamePrefix("async-trade-pool-");
+        executor.initialize();
+
+        return executor;
+    }
+}

--- a/src/main/java/com/r307/arbitrader/config/AppConfig.java
+++ b/src/main/java/com/r307/arbitrader/config/AppConfig.java
@@ -13,8 +13,8 @@ public class AppConfig {
     public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         // Open to discussion
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(2);
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
         executor.setQueueCapacity(5);
         executor.setThreadNamePrefix("async-trade-pool-");
         executor.initialize();

--- a/src/main/java/com/r307/arbitrader/service/ExchangeService.java
+++ b/src/main/java/com/r307/arbitrader/service/ExchangeService.java
@@ -1,15 +1,45 @@
 package com.r307.arbitrader.service;
 
 import com.r307.arbitrader.config.ExchangeConfiguration;
+import com.r307.arbitrader.service.ticker.TickerStrategy;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.account.Fee;
+import org.knowm.xchange.dto.account.Wallet;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.marketdata.params.CurrencyPairsParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import static com.r307.arbitrader.service.TradingService.METADATA_KEY;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Map;
+
+import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
+import static com.r307.arbitrader.service.TradingScheduler.METADATA_KEY;
 
 @Component
 public class ExchangeService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExchangeService.class);
+
+    public static final String METADATA_KEY = "arbitrader-metadata";
+    public static final String TICKER_STRATEGY_KEY = "tickerStrategy";
+
+    private final Map<String, TickerStrategy> tickerStrategies;
+    private final ExchangeFeeCache feeCache;
+
+    @Inject
+    public ExchangeService(Map<String, TickerStrategy> tickerStrategies, ExchangeFeeCache feeCache) {
+        this.tickerStrategies = tickerStrategies;
+        this.feeCache = feeCache;
+    }
+
     public ExchangeConfiguration getExchangeMetadata(Exchange exchange) {
         return (ExchangeConfiguration) exchange.getExchangeSpecification().getExchangeSpecificParametersItem(METADATA_KEY);
     }
@@ -26,5 +56,158 @@ public class ExchangeService {
         }
 
         return currencyPair;
+    }
+
+    public void setUpExchange(Exchange exchange) {
+        try {
+            LOGGER.debug("{} SSL URI: {}",
+                exchange.getExchangeSpecification().getExchangeName(),
+                exchange.getExchangeSpecification().getSslUri());
+            LOGGER.debug("{} SSL host: {}",
+                exchange.getExchangeSpecification().getExchangeName(),
+                exchange.getExchangeSpecification().getHost());
+            LOGGER.debug("{} SSL port: {}",
+                exchange.getExchangeSpecification().getExchangeName(),
+                exchange.getExchangeSpecification().getPort());
+            LOGGER.debug("{} home currency: {}",
+                exchange.getExchangeSpecification().getExchangeName(),
+                getExchangeHomeCurrency(exchange));
+            LOGGER.info("{} balance: {}{}",
+                exchange.getExchangeSpecification().getExchangeName(),
+                getExchangeHomeCurrency(exchange).getSymbol(),
+                getAccountBalance(exchange));
+        } catch (IOException e) {
+            LOGGER.error("Unable to fetch account balance: ", e);
+        }
+
+
+        if (exchange.getExchangeSpecification().getExchangeClassName().contains("Streaming")) {
+            exchange.getExchangeSpecification().setExchangeSpecificParametersItem(TICKER_STRATEGY_KEY, tickerStrategies.get("streamingTickerStrategy"));
+        } else {
+            try {
+                CurrencyPairsParam param = () -> getExchangeMetadata(exchange).getTradingPairs().subList(0, 1);
+                exchange.getMarketDataService().getTickers(param);
+
+                exchange.getExchangeSpecification().setExchangeSpecificParametersItem(TICKER_STRATEGY_KEY, tickerStrategies.get("singleCallTickerStrategy"));
+            } catch (NotYetImplementedForExchangeException e) {
+                LOGGER.warn("{} does not support fetching multiple tickers at a time and will fetch tickers " +
+                        "individually instead. This may result in API rate limiting.",
+                    exchange.getExchangeSpecification().getExchangeName());
+
+                exchange.getExchangeSpecification().setExchangeSpecificParametersItem(TICKER_STRATEGY_KEY, tickerStrategies.get("parallelTickerStrategy"));
+            } catch (IOException e) {
+                LOGGER.debug("IOException fetching tickers for {}: ", exchange.getExchangeSpecification().getExchangeName(), e);
+            }
+        }
+
+        BigDecimal tradingFee = getExchangeFee(exchange, convertExchangePair(exchange, CurrencyPair.BTC_USD), false);
+
+        LOGGER.info("{} ticker strategy: {}",
+            exchange.getExchangeSpecification().getExchangeName(),
+            exchange.getExchangeSpecification().getExchangeSpecificParametersItem(TICKER_STRATEGY_KEY));
+
+        LOGGER.info("{} {} trading fee: {}",
+            exchange.getExchangeSpecification().getExchangeName(),
+            convertExchangePair(exchange, CurrencyPair.BTC_USD),
+            tradingFee);
+    }
+
+
+    public BigDecimal getAccountBalance(Exchange exchange, Currency currency) throws IOException {
+        return getAccountBalance(exchange, currency, USD_SCALE);
+    }
+
+    public BigDecimal getAccountBalance(Exchange exchange) throws IOException {
+        Currency currency = getExchangeHomeCurrency(exchange);
+
+        return getAccountBalance(exchange, currency);
+    }
+
+    public BigDecimal getExchangeFee(Exchange exchange, CurrencyPair currencyPair, boolean isQuiet) {
+        BigDecimal cachedFee = feeCache.getCachedFee(exchange, currencyPair);
+
+        if (cachedFee != null) {
+            return cachedFee;
+        }
+
+        // if an explicit override is configured, default to that
+        if (getExchangeMetadata(exchange).getFeeOverride() != null) {
+            BigDecimal fee = getExchangeMetadata(exchange).getFeeOverride();
+            feeCache.setCachedFee(exchange, currencyPair, fee);
+
+            LOGGER.trace("Using explicitly configured fee override of {} for {}",
+                fee,
+                exchange.getExchangeSpecification().getExchangeName());
+
+            return fee;
+        }
+
+        try {
+            Map<CurrencyPair, Fee> fees = exchange.getAccountService().getDynamicTradingFees();
+
+            if (fees.containsKey(currencyPair)) {
+                BigDecimal fee = fees.get(currencyPair).getMakerFee();
+
+                // We're going to cache this value. Fees don't change all that often and we don't want to use up
+                // our allowance of API calls just checking the fees.
+                feeCache.setCachedFee(exchange, currencyPair, fee);
+
+                LOGGER.trace("Using dynamic maker fee for {}",
+                    exchange.getExchangeSpecification().getExchangeName());
+
+                return fee;
+            }
+        } catch (NotYetImplementedForExchangeException e) {
+            LOGGER.trace("Dynamic fees not yet implemented for {}, will try other methods",
+                exchange.getExchangeSpecification().getExchangeName());
+        } catch (IOException e) {
+            LOGGER.trace("IOE fetching dynamic trading fees for {}",
+                exchange.getExchangeSpecification().getExchangeName());
+        } catch (Exception e) {
+            LOGGER.warn("Programming error in XChange! {} when calling getDynamicTradingFees() for exchange: {}",
+                e.getClass().getName(),
+                exchange.getExchangeSpecification().getExchangeName());
+        }
+
+        CurrencyPairMetaData currencyPairMetaData = exchange.getExchangeMetaData().getCurrencyPairs().get(convertExchangePair(exchange, currencyPair));
+
+        if (currencyPairMetaData == null || currencyPairMetaData.getTradingFee() == null) {
+            BigDecimal configuredFee = getExchangeMetadata(exchange).getFee();
+
+            if (configuredFee == null) {
+                if (!isQuiet) {
+                    LOGGER.error("{} has no fees configured. Setting default of 0.0030. Please configure the correct value!",
+                        exchange.getExchangeSpecification().getExchangeName());
+                }
+
+                return new BigDecimal("0.0030");
+            }
+
+            if (!isQuiet) {
+                LOGGER.warn("{} fees unavailable via API. Will use configured value.",
+                    exchange.getExchangeSpecification().getExchangeName());
+            }
+
+            return configuredFee;
+        }
+
+        return currencyPairMetaData.getTradingFee();
+    }
+
+    public BigDecimal getAccountBalance(Exchange exchange, Currency currency, int scale) throws IOException {
+        AccountService accountService = exchange.getAccountService();
+
+        for (Wallet wallet : accountService.getAccountInfo().getWallets().values()) {
+            if (wallet.getBalances().containsKey(currency)) {
+                return wallet.getBalance(currency).getAvailable()
+                    .setScale(scale, RoundingMode.HALF_EVEN);
+            }
+        }
+
+        LOGGER.error("{}: Unable to fetch {} balance",
+            exchange.getExchangeSpecification().getExchangeName(),
+            currency.getCurrencyCode());
+
+        return BigDecimal.ZERO;
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/SpreadService.java
+++ b/src/main/java/com/r307/arbitrader/service/SpreadService.java
@@ -1,17 +1,22 @@
 package com.r307.arbitrader.service;
 
 import com.r307.arbitrader.service.model.Spread;
+import com.r307.arbitrader.service.model.TradeCombination;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.Ticker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
 
 @Component
 public class SpreadService {
@@ -21,6 +26,11 @@ public class SpreadService {
     private final Map<String, BigDecimal> maxSpreadIn = new HashMap<>();
     private final Map<String, BigDecimal> minSpreadOut = new HashMap<>();
     private final Map<String, BigDecimal> maxSpreadOut = new HashMap<>();
+    private final TickerService tickerService;
+
+    public SpreadService(TickerService tickerService) {
+        this.tickerService = tickerService;
+    }
 
     public void publish(Spread spread) {
         String spreadKey = spreadKey(spread.getLongExchange(), spread.getShortExchange(), spread.getCurrencyPair());
@@ -37,6 +47,42 @@ public class SpreadService {
         LOGGER.info("Maximum spreadIns:\n{}", buildSummary(maxSpreadIn));
         LOGGER.info("Minimum spreadOuts:\n{}", buildSummary(minSpreadOut));
         LOGGER.info("Maximum spreadOuts:\n{}", buildSummary(maxSpreadOut));
+    }
+
+    public Spread computeSpread(TradeCombination tradeCombination) {
+        Exchange longExchange = tradeCombination.getLongExchange();
+        Exchange shortExchange = tradeCombination.getShortExchange();
+        CurrencyPair currencyPair = tradeCombination.getCurrencyPair();
+
+        Ticker longTicker = tickerService.getTicker(longExchange, currencyPair);
+        Ticker shortTicker = tickerService.getTicker(shortExchange, currencyPair);
+
+        if (tickerService.isInvalidTicker(longTicker) || tickerService.isInvalidTicker(shortTicker)) {
+            return null;
+        }
+
+        BigDecimal spreadIn = computeSpread(longTicker.getAsk(), shortTicker.getBid());
+        BigDecimal spreadOut = computeSpread(longTicker.getBid(), shortTicker.getAsk());
+
+        Spread spread = new Spread(
+            currencyPair,
+            longExchange,
+            shortExchange,
+            longTicker,
+            shortTicker,
+            spreadIn,
+            spreadOut);
+
+        publish(spread);
+
+        return spread;
+    }
+
+    public BigDecimal computeSpread(BigDecimal longPrice, BigDecimal shortPrice) {
+        BigDecimal scaledLongPrice = longPrice.setScale(BTC_SCALE, RoundingMode.HALF_EVEN);
+        BigDecimal scaledShortPrice = shortPrice.setScale(BTC_SCALE, RoundingMode.HALF_EVEN);
+
+        return (scaledShortPrice.subtract(scaledLongPrice)).divide(scaledLongPrice, RoundingMode.HALF_EVEN);
     }
 
     private String buildSummary(Map<String, BigDecimal> spreadMap) {

--- a/src/main/java/com/r307/arbitrader/service/TickerService.java
+++ b/src/main/java/com/r307/arbitrader/service/TickerService.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.r307.arbitrader.service.TradingService.TICKER_STRATEGY_KEY;
+import static com.r307.arbitrader.service.TradingScheduler.TICKER_STRATEGY_KEY;
 
 @Component
 public class TickerService {
@@ -86,11 +86,8 @@ public class TickerService {
 
         // find the currencies that are actively in use for each exchange
         tradeCombinations.forEach(tradeCombination -> {
-            Set<CurrencyPair> longCurrencies = queue.computeIfAbsent(tradeCombination.getLongExchange(), (key) -> new HashSet<>());
-            Set<CurrencyPair> shortCurrencies = queue.computeIfAbsent(tradeCombination.getShortExchange(), (key) -> new HashSet<>());
-
-            longCurrencies.add(tradeCombination.getCurrencyPair());
-            shortCurrencies.add(tradeCombination.getCurrencyPair());
+            queue.computeIfAbsent(tradeCombination.getLongExchange(), (key) -> new HashSet<>());
+            queue.computeIfAbsent(tradeCombination.getShortExchange(), (key) -> new HashSet<>());
         });
 
         // for each exchange, fetch its active currencies

--- a/src/main/java/com/r307/arbitrader/service/TickerService.java
+++ b/src/main/java/com/r307/arbitrader/service/TickerService.java
@@ -1,5 +1,6 @@
 package com.r307.arbitrader.service;
 
+import com.r307.arbitrader.Utils;
 import com.r307.arbitrader.config.TradingConfiguration;
 import com.r307.arbitrader.service.model.TradeCombination;
 import com.r307.arbitrader.service.ticker.TickerStrategy;
@@ -33,7 +34,8 @@ public class TickerService {
     private final ErrorCollectorService errorCollectorService;
 
     Map<String, Ticker> allTickers = new HashMap<>();
-    List<TradeCombination> tradeCombinations = new ArrayList<>();
+    List<TradeCombination> pollingExchangeTradeCombinations = new ArrayList<>();
+    List<TradeCombination> streamingExchangeTradeCombinations = new ArrayList<>();
 
     @Inject
     public TickerService(
@@ -70,9 +72,14 @@ public class TickerService {
                     return;
                 }
 
-                TradeCombination combination = new TradeCombination(longExchange, shortExchange, currencyPair);
+                final TradeCombination combination = new TradeCombination(longExchange, shortExchange, currencyPair);
 
-                tradeCombinations.add(combination);
+                if (Utils.isStreamingExchange(longExchange) && Utils.isStreamingExchange(shortExchange)) {
+                    streamingExchangeTradeCombinations.add(combination);
+                }
+
+                // We still want to use streaming exchanges when we are polling
+                pollingExchangeTradeCombinations.add(combination);
 
                 LOGGER.info("{}", combination);
             });
@@ -85,7 +92,7 @@ public class TickerService {
         Map<Exchange, Set<CurrencyPair>> queue = new HashMap<>();
 
         // find the currencies that are actively in use for each exchange
-        tradeCombinations.forEach(tradeCombination -> {
+        pollingExchangeTradeCombinations.forEach(tradeCombination -> {
             queue.computeIfAbsent(tradeCombination.getLongExchange(), (key) -> new HashSet<>());
             queue.computeIfAbsent(tradeCombination.getShortExchange(), (key) -> new HashSet<>());
         });
@@ -113,14 +120,21 @@ public class TickerService {
         return ticker == null || ticker.getBid() == null || ticker.getAsk() == null;
     }
 
-    public List<TradeCombination> getTradeCombinations() {
-        List<TradeCombination> result = new ArrayList<>(tradeCombinations);
+    public List<TradeCombination> getTradeCombinations(boolean streamingExchange) {
+        if (streamingExchange) {
+            final List<TradeCombination> streamingResult = new ArrayList<>(streamingExchangeTradeCombinations);
+            Collections.shuffle(streamingResult);
+
+            return streamingResult;
+        }
+
+        final List<TradeCombination> allResult = new ArrayList<>(pollingExchangeTradeCombinations);
 
         // If everything is always evaluated in the same order, earlier exchange/pair combos have a higher chance of
         // executing trades than ones at the end of the list.
-        Collections.shuffle(result);
+        Collections.shuffle(allResult);
 
-        return result;
+        return allResult;
     }
 
     // TODO test public API instead of private

--- a/src/main/java/com/r307/arbitrader/service/TickerService.java
+++ b/src/main/java/com/r307/arbitrader/service/TickerService.java
@@ -120,14 +120,7 @@ public class TickerService {
         return ticker == null || ticker.getBid() == null || ticker.getAsk() == null;
     }
 
-    public List<TradeCombination> getTradeCombinations(boolean streamingExchange) {
-        if (streamingExchange) {
-            final List<TradeCombination> streamingResult = new ArrayList<>(streamingExchangeTradeCombinations);
-            Collections.shuffle(streamingResult);
-
-            return streamingResult;
-        }
-
+    public List<TradeCombination> getPollingExchangeTradeCombinations() {
         final List<TradeCombination> allResult = new ArrayList<>(pollingExchangeTradeCombinations);
 
         // If everything is always evaluated in the same order, earlier exchange/pair combos have a higher chance of
@@ -135,6 +128,13 @@ public class TickerService {
         Collections.shuffle(allResult);
 
         return allResult;
+    }
+
+    public List<TradeCombination> getStreamingExchangeTradeCombinations() {
+        final List<TradeCombination> streamingResult = new ArrayList<>(streamingExchangeTradeCombinations);
+        Collections.shuffle(streamingResult);
+
+        return streamingResult;
     }
 
     // TODO test public API instead of private

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -161,7 +161,7 @@ public class TradingScheduler {
     public void summary() {
         LOGGER.info("Summary: [Long/Short Exchanges] [Pair] [Current Spread] -> [{} Spread Target]", (activePosition != null ? "Exit" : "Entry"));
 
-        List<TradeCombination> tradeCombinations = tickerService.getTradeCombinations();
+        List<TradeCombination> tradeCombinations = tickerService.getTradeCombinations(false);
 
         tradeCombinations.forEach(tradeCombination -> {
             Spread spread = spreadService.computeSpread(tradeCombination);
@@ -210,7 +210,7 @@ public class TradingScheduler {
         tickerService.refreshTickers();
 
         long exchangePollStartTime = System.currentTimeMillis();
-        startTradingProcess();
+        startTradingProcess(false);
 
         long exchangePollDuration = System.currentTimeMillis() - exchangePollStartTime;
 
@@ -219,8 +219,8 @@ public class TradingScheduler {
         }
     }
 
-    public void startTradingProcess() {
-        tickerService.getTradeCombinations()
+    public void startTradingProcess(boolean isStreaming) {
+        tickerService.getTradeCombinations(isStreaming)
             .forEach(tradeCombination -> {
                 Spread spread = spreadService.computeSpread(tradeCombination);
 

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -7,34 +7,21 @@ import com.r307.arbitrader.exception.OrderNotFoundException;
 import com.r307.arbitrader.service.model.ActivePosition;
 import com.r307.arbitrader.service.model.ArbitrageLog;
 import com.r307.arbitrader.service.model.Spread;
-import com.r307.arbitrader.service.model.TradeCombination;
-import com.r307.arbitrader.service.ticker.TickerStrategy;
-import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import org.apache.commons.io.FileUtils;
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.ExchangeFactory;
-import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
-import org.knowm.xchange.dto.account.Fee;
-import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
-import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
-import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
-import org.knowm.xchange.service.account.AccountService;
-import org.knowm.xchange.service.marketdata.params.CurrencyPairsParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -42,22 +29,16 @@ import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
-import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
 
 @Component
 public class TradingService {
-    public static final String METADATA_KEY = "arbitrader-metadata";
-    public static final String TICKER_STRATEGY_KEY = "tickerStrategy";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TradingService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TradingScheduler.class);
     private static final String STATE_FILE = ".arbitrader/arbitrader-state.json";
     protected static final String TRADE_HISTORY_FILE = ".arbitrader/arbitrader-arbitrage-history.csv";
 
@@ -69,277 +50,73 @@ public class TradingService {
 
     private final ObjectMapper objectMapper;
     private final TradingConfiguration tradingConfiguration;
-    private final ExchangeFeeCache feeCache;
     private final ConditionService conditionService;
     private final ExchangeService exchangeService;
-    private final ErrorCollectorService errorCollectorService;
     private final SpreadService spreadService;
     private final TickerService tickerService;
     private final NotificationService notificationService;
-    private final Map<String, TickerStrategy> tickerStrategies;
-    private final List<Exchange> exchanges = new ArrayList<>();
-    private boolean bailOut = false;
     private boolean timeoutExitWarning = false;
     private ActivePosition activePosition = null;
+    private boolean bailOut = false;
 
     public TradingService(
         ObjectMapper objectMapper,
         TradingConfiguration tradingConfiguration,
-        ExchangeFeeCache feeCache,
         ConditionService conditionService,
         ExchangeService exchangeService,
-        ErrorCollectorService errorCollectorService,
         SpreadService spreadService,
         TickerService tickerService,
-        NotificationService notificationService,
-        Map<String, TickerStrategy> tickerStrategies) {
+        NotificationService notificationService) {
 
         this.objectMapper = objectMapper;
         this.tradingConfiguration = tradingConfiguration;
-        this.feeCache = feeCache;
         this.conditionService = conditionService;
         this.exchangeService = exchangeService;
-        this.errorCollectorService = errorCollectorService;
         this.spreadService = spreadService;
         this.tickerService = tickerService;
-        this.tickerStrategies = tickerStrategies;
         this.notificationService = notificationService;
     }
 
-    @PostConstruct
-    public void connectExchanges() {
-        tradingConfiguration.getExchanges().forEach(exchangeMetadata -> {
-            ExchangeSpecification specification = new ExchangeSpecification(exchangeMetadata.getExchangeClass());
+    public void startTradingProcess() {
+        tickerService.getTradeCombinations()
+            .forEach(tradeCombination -> {
+                Spread spread = spreadService.computeSpread(tradeCombination);
 
-            specification.setUserName(exchangeMetadata.getUserName());
-            specification.setApiKey(exchangeMetadata.getApiKey());
-            specification.setSecretKey(exchangeMetadata.getSecretKey());
-
-            if (exchangeMetadata.getSslUri() != null) {
-                specification.setSslUri(exchangeMetadata.getSslUri());
-            }
-
-            if (exchangeMetadata.getHost() != null) {
-                specification.setHost(exchangeMetadata.getHost());
-            }
-
-            if (exchangeMetadata.getPort() != null) {
-                specification.setPort(exchangeMetadata.getPort());
-            }
-
-            if (!exchangeMetadata.getCustom().isEmpty()) {
-                exchangeMetadata.getCustom().forEach((key, value) -> {
-                    if ("true".equals(value) || "false".equals(value)) {
-                        specification.setExchangeSpecificParametersItem(key, Boolean.valueOf(value));
-                    } else {
-                        specification.setExchangeSpecificParametersItem(key, value);
-                    }
-                });
-            }
-
-            specification.setExchangeSpecificParametersItem(METADATA_KEY, exchangeMetadata);
-
-            if (specification.getExchangeClassName().contains("Streaming")) {
-                exchanges.add(StreamingExchangeFactory.INSTANCE.createExchange(specification));
-            } else {
-                exchanges.add(ExchangeFactory.INSTANCE.createExchange(specification));
-            }
-        });
-
-        exchanges.forEach(exchange -> {
-            try {
-                LOGGER.debug("{} SSL URI: {}",
-                        exchange.getExchangeSpecification().getExchangeName(),
-                        exchange.getExchangeSpecification().getSslUri());
-                LOGGER.debug("{} SSL host: {}",
-                        exchange.getExchangeSpecification().getExchangeName(),
-                        exchange.getExchangeSpecification().getHost());
-                LOGGER.debug("{} SSL port: {}",
-                        exchange.getExchangeSpecification().getExchangeName(),
-                        exchange.getExchangeSpecification().getPort());
-                LOGGER.debug("{} home currency: {}",
-                        exchange.getExchangeSpecification().getExchangeName(),
-                        exchangeService.getExchangeHomeCurrency(exchange));
-                LOGGER.info("{} balance: {}{}",
-                        exchange.getExchangeSpecification().getExchangeName(),
-                    exchangeService.getExchangeHomeCurrency(exchange).getSymbol(),
-                        getAccountBalance(exchange));
-            } catch (IOException e) {
-                LOGGER.error("Unable to fetch account balance: ", e);
-            }
-
-            if (exchange.getExchangeSpecification().getExchangeClassName().contains("Streaming")) {
-                exchange.getExchangeSpecification().setExchangeSpecificParametersItem(TICKER_STRATEGY_KEY, tickerStrategies.get("streamingTickerStrategy"));
-            } else {
-                try {
-                    CurrencyPairsParam param = () -> exchangeService.getExchangeMetadata(exchange).getTradingPairs().subList(0, 1);
-                    exchange.getMarketDataService().getTickers(param);
-
-                    exchange.getExchangeSpecification().setExchangeSpecificParametersItem(TICKER_STRATEGY_KEY, tickerStrategies.get("singleCallTickerStrategy"));
-                } catch (NotYetImplementedForExchangeException e) {
-                    LOGGER.warn("{} does not support fetching multiple tickers at a time and will fetch tickers " +
-                            "individually instead. This may result in API rate limiting.",
-                        exchange.getExchangeSpecification().getExchangeName());
-
-                    exchange.getExchangeSpecification().setExchangeSpecificParametersItem(TICKER_STRATEGY_KEY, tickerStrategies.get("parallelTickerStrategy"));
-                } catch (IOException e) {
-                    LOGGER.debug("IOException fetching tickers for {}: ", exchange.getExchangeSpecification().getExchangeName(), e);
+                if (spread != null) {
+                    trade(spread);
                 }
-            }
-
-            BigDecimal tradingFee = getExchangeFee(exchange, exchangeService.convertExchangePair(exchange, CurrencyPair.BTC_USD), false);
-
-            LOGGER.info("{} ticker strategy: {}",
-                exchange.getExchangeSpecification().getExchangeName(),
-                exchange.getExchangeSpecification().getExchangeSpecificParametersItem(TICKER_STRATEGY_KEY));
-
-            LOGGER.info("{} {} trading fee: {}",
-                exchange.getExchangeSpecification().getExchangeName(),
-                exchangeService.convertExchangePair(exchange, CurrencyPair.BTC_USD),
-                tradingFee);
-        });
-
-        tickerService.initializeTickers(exchanges);
-
-        if (tradingConfiguration.getFixedExposure() != null) {
-            LOGGER.info("Using fixed exposure of ${} as configured", tradingConfiguration.getFixedExposure());
-        }
-
-        if (tradingConfiguration.getTradeTimeout() != null) {
-            LOGGER.info("Using trade timeout of {} hours", tradingConfiguration.getTradeTimeout());
-        }
-
-        // load active trades from file, if there is one
-        File stateFile = new File(STATE_FILE);
-
-        if (stateFile.exists()) {
-            if (!stateFile.canRead()) {
-                LOGGER.error("Cannot read state file: {}", stateFile.getAbsolutePath());
-            } else {
-                try {
-                    activePosition = objectMapper.readValue(stateFile, ActivePosition.class);
-
-                    LOGGER.info("Loaded active trades from file: {}", stateFile.getAbsolutePath());
-                    LOGGER.info("Active trades: {}", activePosition);
-                } catch (IOException e) {
-                    LOGGER.error("Unable to parse state file {}: ", stateFile.getAbsolutePath(), e);
-                }
-            }
-        }
+            });
     }
 
-    /**
-     * As often as once per minute, display a summary of any non-critical error messages. Summarizing them greatly
-     * reduces how noisy the logs are while still providing the same information.
-     */
-    @Scheduled(cron = "0 * * * * *")
-    public void errorSummary() {
-        if (!errorCollectorService.isEmpty()) {
-            errorCollectorService.report().forEach(LOGGER::info);
-            errorCollectorService.clear();
-        }
-    }
+    public void trade(Spread spread) {
+        final String shortExchangeName = spread.getShortExchange().getExchangeSpecification().getExchangeName();
+        final String longExchangeName = spread.getLongExchange().getExchangeSpecification().getExchangeName();
 
-    /**
-     * Display a summary once every 6 hours with the current spreads.
-     */
-    @Scheduled(cron = "0 0 0/6 * * *") // every 6 hours
-    public void summary() {
-        LOGGER.info("Summary: [Long/Short Exchanges] [Pair] [Current Spread] -> [{} Spread Target]", (activePosition != null ? "Exit" : "Entry"));
+        LOGGER.debug("Long/Short: {}/{} {} {}",
+            longExchangeName,
+            shortExchangeName,
+            spread.getCurrencyPair(),
+            spread.getIn());
 
-        List<TradeCombination> tradeCombinations = tickerService.getTradeCombinations();
-
-        tradeCombinations.forEach(tradeCombination -> {
-            Spread spread = computeSpread(tradeCombination);
-
-            if (spread == null) {
+        if (!conditionService.isForceCloseCondition() && spread.getIn().compareTo(tradingConfiguration.getEntrySpread()) > 0) {
+            if (activePosition != null) {
                 return;
             }
 
-            if (activePosition == null && BigDecimal.ZERO.compareTo(spread.getIn()) < 0) {
-                LOGGER.info("{}/{} {} {} -> {}",
-                    spread.getLongExchange().getExchangeSpecification().getExchangeName(),
-                    spread.getShortExchange().getExchangeSpecification().getExchangeName(),
-                    spread.getCurrencyPair(),
-                    spread.getIn(),
-                    tradingConfiguration.getEntrySpread());
-            } else if (activePosition != null
-                && activePosition.getCurrencyPair().equals(spread.getCurrencyPair())
-                && activePosition.getLongTrade().getExchange().equals(spread.getLongExchange().getExchangeSpecification().getExchangeName())
-                && activePosition.getShortTrade().getExchange().equals(spread.getShortExchange().getExchangeSpecification().getExchangeName())) {
+            entryPosition(spread, shortExchangeName, longExchangeName);
+        } else if (activePosition != null
+            && spread.getCurrencyPair().equals(activePosition.getCurrencyPair())
+            && longExchangeName.equals(activePosition.getLongTrade().getExchange())
+            && shortExchangeName.equals(activePosition.getShortTrade().getExchange())
+            && (spread.getOut().compareTo(activePosition.getExitTarget()) < 0 || conditionService.isForceCloseCondition() || isTradeExpired())) {
 
-                LOGGER.info("{}/{} {} {} -> {}",
-                    spread.getLongExchange().getExchangeSpecification().getExchangeName(),
-                    spread.getShortExchange().getExchangeSpecification().getExchangeName(),
-                    spread.getCurrencyPair(),
-                    spread.getOut(),
-                    activePosition.getExitTarget());
-            }
-        });
-    }
-
-    @Scheduled(initialDelay = 5000, fixedRate = 3000)
-    public void tick() {
-        LOGGER.debug("Tick");
-
-        if (bailOut) {
-            LOGGER.error("Exiting immediately to avoid erroneous trades.");
-            System.exit(1);
-        }
-
-        if (activePosition == null && conditionService.isExitWhenIdleCondition()) {
-            LOGGER.info("Exiting at user request");
-            conditionService.clearExitWhenIdleCondition();
-            System.exit(0);
-        }
-
-        tickerService.refreshTickers();
-
-        long exchangePollStartTime = System.currentTimeMillis();
-        List<TradeCombination> tradeCombinations = tickerService.getTradeCombinations();
-
-        tradeCombinations.forEach(tradeCombination -> {
-            Spread spread = computeSpread(tradeCombination);
-
-            if (spread == null) {
-                return;
-            }
-
-            final String shortExchangeName = spread.getShortExchange().getExchangeSpecification().getExchangeName();
-            final String longExchangeName = spread.getLongExchange().getExchangeSpecification().getExchangeName();
-
-            LOGGER.debug("Long/Short: {}/{} {} {}",
-                longExchangeName,
-                shortExchangeName,
-                spread.getCurrencyPair(),
-                spread.getIn());
-
-            if (!conditionService.isForceCloseCondition() && spread.getIn().compareTo(tradingConfiguration.getEntrySpread()) > 0) {
-                if (activePosition != null) {
-                    return;
-                }
-
-                entryPosition(spread, shortExchangeName, longExchangeName);
-            } else if (activePosition != null
-                    && spread.getCurrencyPair().equals(activePosition.getCurrencyPair())
-                    && longExchangeName.equals(activePosition.getLongTrade().getExchange())
-                    && shortExchangeName.equals(activePosition.getShortTrade().getExchange())
-                    && (spread.getOut().compareTo(activePosition.getExitTarget()) < 0 || conditionService.isForceCloseCondition() || isTradeExpired())) {
-
-                exitPosition(spread, shortExchangeName, longExchangeName);
-            }
-        });
-
-        long exchangePollDuration = System.currentTimeMillis() - exchangePollStartTime;
-
-        if (exchangePollDuration > 3000) {
-            LOGGER.warn("Polling exchanges took {} ms", exchangePollDuration);
+            exitPosition(spread, shortExchangeName, longExchangeName);
         }
     }
 
     private void entryPosition(Spread spread, String shortExchangeName, String longExchangeName) {
-        final BigDecimal longFees = getExchangeFee(spread.getLongExchange(), spread.getCurrencyPair(), true);
-        final BigDecimal shortFees = getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);
+        final BigDecimal longFees = exchangeService.getExchangeFee(spread.getLongExchange(), spread.getCurrencyPair(), true);
+        final BigDecimal shortFees = exchangeService.getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);
         final CurrencyPair currencyPairLongExchange = exchangeService.convertExchangePair(spread.getLongExchange(), spread.getCurrencyPair());
         final CurrencyPair currencyPairShortExchange = exchangeService.convertExchangePair(spread.getShortExchange(), spread.getCurrencyPair());
 
@@ -407,7 +184,7 @@ public class TradingService {
             return;
         }
 
-        BigDecimal spreadVerification = computeSpread(longLimitPrice, shortLimitPrice);
+        BigDecimal spreadVerification = spreadService.computeSpread(longLimitPrice, shortLimitPrice);
 
         if (spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
             LOGGER.debug("Not enough liquidity to execute both trades profitably");
@@ -423,33 +200,33 @@ public class TradingService {
 
         BigDecimal totalBalance = logCurrentExchangeBalances(spread.getLongExchange(), spread.getShortExchange());
 
-        try {
-            activePosition = new ActivePosition();
-            activePosition.setEntryTime(OffsetDateTime.now());
-            activePosition.setCurrencyPair(spread.getCurrencyPair());
-            activePosition.setExitTarget(exitTarget);
-            activePosition.setEntryBalance(totalBalance);
-            activePosition.getLongTrade().setExchange(spread.getLongExchange());
-            activePosition.getLongTrade().setVolume(longVolume);
-            activePosition.getLongTrade().setEntry(longLimitPrice);
-            activePosition.getShortTrade().setExchange(spread.getShortExchange());
-            activePosition.getShortTrade().setVolume(shortVolume);
-            activePosition.getShortTrade().setEntry(shortLimitPrice);
+//        try {
+        activePosition = new ActivePosition();
+        activePosition.setEntryTime(OffsetDateTime.now());
+        activePosition.setCurrencyPair(spread.getCurrencyPair());
+        activePosition.setExitTarget(exitTarget);
+        activePosition.setEntryBalance(totalBalance);
+        activePosition.getLongTrade().setExchange(spread.getLongExchange());
+        activePosition.getLongTrade().setVolume(longVolume);
+        activePosition.getLongTrade().setEntry(longLimitPrice);
+        activePosition.getShortTrade().setExchange(spread.getShortExchange());
+        activePosition.getShortTrade().setVolume(shortVolume);
+        activePosition.getShortTrade().setEntry(shortLimitPrice);
 
-            executeOrderPair(
-                    spread.getLongExchange(), spread.getShortExchange(),
-                    spread.getCurrencyPair(),
-                    longLimitPrice, shortLimitPrice,
-                    longVolume, shortVolume,
-                    true);
+//            executeOrderPair(
+//                    spread.getLongExchange(), spread.getShortExchange(),
+//                    spread.getCurrencyPair(),
+//                    longLimitPrice, shortLimitPrice,
+//                    longVolume, shortVolume,
+//                    true);
 
-            notificationService.sendEmailNotificationBodyForEntryTrade(spread, exitTarget, longVolume,
-                    longLimitPrice, shortVolume, shortLimitPrice);
+        notificationService.sendEmailNotificationBodyForEntryTrade(spread, exitTarget, longVolume,
+            longLimitPrice, shortVolume, shortLimitPrice);
 
-            } catch (IOException e) {
-                LOGGER.error("IOE executing limit orders: ", e);
-                activePosition = null;
-            }
+//            } catch (IOException e) {
+//                LOGGER.error("IOE executing limit orders: ", e);
+//                activePosition = null;
+//            }
 
         try {
             FileUtils.write(new File(STATE_FILE), objectMapper.writeValueAsString(activePosition), Charset.defaultCharset());
@@ -524,7 +301,7 @@ public class TradingService {
 
         LOGGER.debug("Limit prices: {}/{}", longLimitPrice, shortLimitPrice);
 
-        BigDecimal spreadVerification = computeSpread(longLimitPrice, shortLimitPrice);
+        BigDecimal spreadVerification = spreadService.computeSpread(longLimitPrice, shortLimitPrice);
 
         LOGGER.debug("Spread verification: {}", spreadVerification);
 
@@ -554,36 +331,36 @@ public class TradingService {
 
         logExitTrade();
 
-        try {
-            LOGGER.info("Long close: {} {} {} @ {} ({} slip) = {}{}",
-                longExchangeName,
-                spread.getCurrencyPair(),
-                longVolume,
-                longLimitPrice,
-                longLimitPrice.subtract(spread.getLongTicker().getBid()),
-                Currency.USD.getSymbol(),
-                longVolume.multiply(spread.getLongTicker().getBid()));
-            LOGGER.info("Short close: {} {} {} @ {} ({} slip) = {}{}",
-                shortExchangeName,
-                spread.getCurrencyPair(),
-                shortVolume,
-                shortLimitPrice,
-                spread.getShortTicker().getAsk().subtract(shortLimitPrice),
-                Currency.USD.getSymbol(),
-                shortVolume.multiply(spread.getShortTicker().getAsk()));
+//        try {
+        LOGGER.info("Long close: {} {} {} @ {} ({} slip) = {}{}",
+            longExchangeName,
+            spread.getCurrencyPair(),
+            longVolume,
+            longLimitPrice,
+            longLimitPrice.subtract(spread.getLongTicker().getBid()),
+            Currency.USD.getSymbol(),
+            longVolume.multiply(spread.getLongTicker().getBid()));
+        LOGGER.info("Short close: {} {} {} @ {} ({} slip) = {}{}",
+            shortExchangeName,
+            spread.getCurrencyPair(),
+            shortVolume,
+            shortLimitPrice,
+            spread.getShortTicker().getAsk().subtract(shortLimitPrice),
+            Currency.USD.getSymbol(),
+            shortVolume.multiply(spread.getShortTicker().getAsk()));
 
-            executeOrderPair(
-                spread.getLongExchange(), spread.getShortExchange(),
-                spread.getCurrencyPair(),
-                longLimitPrice, shortLimitPrice,
-                longVolume, shortVolume,
-                false);
-        } catch (IOException e) {
-            LOGGER.error("IOE executing limit orders: ", e);
-            // TODO: Why don't we return here? Could it be because the IOException could be, for example, a timeout exception
-            // and we don't know for sure whether the trade was accepted or not?
-            // Maybe we should return here and send a notification so the user is aware of this situation
-        }
+//            executeOrderPair(
+//                spread.getLongExchange(), spread.getShortExchange(),
+//                spread.getCurrencyPair(),
+//                longLimitPrice, shortLimitPrice,
+//                longVolume, shortVolume,
+//                false);
+//        } catch (IOException e) {
+//            LOGGER.error("IOE executing limit orders: ", e);
+//            // TODO: Why don't we return here? Could it be because the IOException could be, for example, a timeout exception
+//            // and we don't know for sure whether the trade was accepted or not?
+//            // Maybe we should return here and send a notification so the user is aware of this situation
+//        }
 
         LOGGER.info("Combined account balances on entry: ${}", activePosition.getEntryBalance());
         BigDecimal updatedBalance = logCurrentExchangeBalances(spread.getLongExchange(), spread.getShortExchange());
@@ -681,77 +458,6 @@ public class TradingService {
         return minimumAmount;
     }
 
-    private BigDecimal getExchangeFee(Exchange exchange, CurrencyPair currencyPair, boolean isQuiet) {
-        BigDecimal cachedFee = feeCache.getCachedFee(exchange, currencyPair);
-
-        if (cachedFee != null) {
-            return cachedFee;
-        }
-
-        // if an explicit override is configured, default to that
-        if (exchangeService.getExchangeMetadata(exchange).getFeeOverride() != null) {
-            BigDecimal fee = exchangeService.getExchangeMetadata(exchange).getFeeOverride();
-            feeCache.setCachedFee(exchange, currencyPair, fee);
-
-            LOGGER.trace("Using explicitly configured fee override of {} for {}",
-                fee,
-                exchange.getExchangeSpecification().getExchangeName());
-
-            return fee;
-        }
-
-        try {
-            Map<CurrencyPair, Fee> fees = exchange.getAccountService().getDynamicTradingFees();
-
-            if (fees.containsKey(currencyPair)) {
-                BigDecimal fee = fees.get(currencyPair).getMakerFee();
-
-                // We're going to cache this value. Fees don't change all that often and we don't want to use up
-                // our allowance of API calls just checking the fees.
-                feeCache.setCachedFee(exchange, currencyPair, fee);
-
-                LOGGER.trace("Using dynamic maker fee for {}",
-                    exchange.getExchangeSpecification().getExchangeName());
-
-                return fee;
-            }
-        } catch (NotYetImplementedForExchangeException e) {
-            LOGGER.trace("Dynamic fees not yet implemented for {}, will try other methods",
-                    exchange.getExchangeSpecification().getExchangeName());
-        } catch (IOException e) {
-            LOGGER.trace("IOE fetching dynamic trading fees for {}",
-                    exchange.getExchangeSpecification().getExchangeName());
-        } catch (Exception e) {
-            LOGGER.warn("Programming error in XChange! {} when calling getDynamicTradingFees() for exchange: {}",
-                    e.getClass().getName(),
-                    exchange.getExchangeSpecification().getExchangeName());
-        }
-
-        CurrencyPairMetaData currencyPairMetaData = exchange.getExchangeMetaData().getCurrencyPairs().get(exchangeService.convertExchangePair(exchange, currencyPair));
-
-        if (currencyPairMetaData == null || currencyPairMetaData.getTradingFee() == null) {
-            BigDecimal configuredFee = exchangeService.getExchangeMetadata(exchange).getFee();
-
-            if (configuredFee == null) {
-                if (!isQuiet) {
-                    LOGGER.error("{} has no fees configured. Setting default of 0.0030. Please configure the correct value!",
-                            exchange.getExchangeSpecification().getExchangeName());
-                }
-
-                return new BigDecimal("0.0030");
-            }
-
-            if (!isQuiet) {
-                LOGGER.warn("{} fees unavailable via API. Will use configured value.",
-                        exchange.getExchangeSpecification().getExchangeName());
-            }
-
-            return configuredFee;
-        }
-
-        return currencyPairMetaData.getTradingFee();
-    }
-
     private void executeOrderPair(Exchange longExchange, Exchange shortExchange,
                                   CurrencyPair currencyPair,
                                   BigDecimal longLimitPrice, BigDecimal shortLimitPrice,
@@ -759,22 +465,22 @@ public class TradingService {
                                   boolean isPositionOpen) throws IOException, ExchangeException {
 
         LimitOrder longLimitOrder = new LimitOrder.Builder(isPositionOpen ? Order.OrderType.BID : Order.OrderType.ASK, exchangeService.convertExchangePair(longExchange, currencyPair))
-                .limitPrice(longLimitPrice)
-                .originalAmount(longVolume)
-                .build();
+            .limitPrice(longLimitPrice)
+            .originalAmount(longVolume)
+            .build();
         LimitOrder shortLimitOrder = new LimitOrder.Builder(isPositionOpen ? Order.OrderType.ASK : Order.OrderType.BID, exchangeService.convertExchangePair(shortExchange, currencyPair))
-                .limitPrice(shortLimitPrice)
-                .originalAmount(shortVolume)
-                .build();
+            .limitPrice(shortLimitPrice)
+            .originalAmount(shortVolume)
+            .build();
 
         shortLimitOrder.setLeverage("2");
 
         LOGGER.debug("{}: {}",
-                longExchange.getExchangeSpecification().getExchangeName(),
-                longLimitOrder);
+            longExchange.getExchangeSpecification().getExchangeName(),
+            longLimitOrder);
         LOGGER.debug("{}: {}",
-                shortExchange.getExchangeSpecification().getExchangeName(),
-                shortLimitOrder);
+            shortExchange.getExchangeSpecification().getExchangeName(),
+            shortLimitOrder);
 
         try {
             String longOrderId = longExchange.getTradeService().placeLimitOrder(longLimitOrder);
@@ -856,13 +562,6 @@ public class TradingService {
         return Optional.empty();
     }
 
-    private BigDecimal computeSpread(BigDecimal longPrice, BigDecimal shortPrice) {
-        BigDecimal scaledLongPrice = longPrice.setScale(BTC_SCALE, RoundingMode.HALF_EVEN);
-        BigDecimal scaledShortPrice = shortPrice.setScale(BTC_SCALE, RoundingMode.HALF_EVEN);
-
-        return (scaledShortPrice.subtract(scaledLongPrice)).divide(scaledLongPrice, RoundingMode.HALF_EVEN);
-    }
-
     BigDecimal getVolumeForOrder(Exchange exchange, CurrencyPair currencyPair, String orderId, BigDecimal defaultVolume) {
         try {
             LOGGER.debug("{}: Attempting to fetch volume from order by ID: {}", exchange.getExchangeSpecification().getExchangeName(), orderId);
@@ -896,7 +595,7 @@ public class TradingService {
         }
 
         try {
-            BigDecimal balance = getAccountBalance(exchange, currencyPair.base);
+            BigDecimal balance = exchangeService.getAccountBalance(exchange, currencyPair.base);
 
             if (BigDecimal.ZERO.compareTo(balance) < 0) {
                 LOGGER.debug("{}: Using {} balance: {}", exchange.getExchangeSpecification().getExchangeName(), currencyPair.base.toString(), balance);
@@ -946,10 +645,10 @@ public class TradingService {
                 .parallel()
                 .map(exchange -> {
                     try {
-                        return getAccountBalance(exchange);
+                        return exchangeService.getAccountBalance(exchange);
                     } catch (IOException e) {
                         LOGGER.trace("IOException fetching {} account balance",
-                                exchange.getExchangeSpecification().getExchangeName());
+                            exchange.getExchangeSpecification().getExchangeName());
                     }
 
                     return BigDecimal.ZERO;
@@ -958,8 +657,8 @@ public class TradingService {
                 .orElse(BigDecimal.ZERO);
 
             BigDecimal exposure = smallestBalance
-                    .multiply(TRADE_PORTION)
-                    .setScale(DecimalConstants.USD_SCALE, RoundingMode.HALF_EVEN);
+                .multiply(TRADE_PORTION)
+                .setScale(DecimalConstants.USD_SCALE, RoundingMode.HALF_EVEN);
 
             LOGGER.debug("Maximum exposure for {}: {}", exchanges, exposure);
 
@@ -969,16 +668,16 @@ public class TradingService {
 
     private BigDecimal logCurrentExchangeBalances(Exchange longExchange, Exchange shortExchange) {
         try {
-            BigDecimal longBalance = getAccountBalance(longExchange);
-            BigDecimal shortBalance = getAccountBalance(shortExchange);
+            BigDecimal longBalance = exchangeService.getAccountBalance(longExchange);
+            BigDecimal shortBalance = exchangeService.getAccountBalance(shortExchange);
             BigDecimal totalBalance = longBalance.add(shortBalance);
 
             LOGGER.info("Updated account balances: {} ${} + {} ${} = ${}",
-                    longExchange.getExchangeSpecification().getExchangeName(),
-                    longBalance,
-                    shortExchange.getExchangeSpecification().getExchangeName(),
-                    shortBalance,
-                    totalBalance);
+                longExchange.getExchangeSpecification().getExchangeName(),
+                longBalance,
+                shortExchange.getExchangeSpecification().getExchangeName(),
+                shortBalance,
+                totalBalance);
 
             return totalBalance;
         } catch (IOException e) {
@@ -986,33 +685,6 @@ public class TradingService {
         }
 
         return BigDecimal.ZERO;
-    }
-
-    BigDecimal getAccountBalance(Exchange exchange, Currency currency, int scale) throws IOException {
-        AccountService accountService = exchange.getAccountService();
-
-        for (Wallet wallet : accountService.getAccountInfo().getWallets().values()) {
-            if (wallet.getBalances().containsKey(currency)) {
-                return wallet.getBalance(currency).getAvailable()
-                        .setScale(scale, RoundingMode.HALF_EVEN);
-            }
-        }
-
-        LOGGER.error("{}: Unable to fetch {} balance",
-            exchange.getExchangeSpecification().getExchangeName(),
-            currency.getCurrencyCode());
-
-        return BigDecimal.ZERO;
-    }
-
-    private BigDecimal getAccountBalance(Exchange exchange, Currency currency) throws IOException {
-        return getAccountBalance(exchange, currency, USD_SCALE);
-    }
-
-    private BigDecimal getAccountBalance(Exchange exchange) throws IOException {
-        Currency currency = exchangeService.getExchangeHomeCurrency(exchange);
-
-        return getAccountBalance(exchange, currency);
     }
 
     /*
@@ -1042,34 +714,6 @@ public class TradingService {
         return activePosition.getEntryTime().plusHours(tradingConfiguration.getTradeTimeout()).isBefore(OffsetDateTime.now());
     }
 
-    private Spread computeSpread(TradeCombination tradeCombination) {
-        Exchange longExchange = tradeCombination.getLongExchange();
-        Exchange shortExchange = tradeCombination.getShortExchange();
-        CurrencyPair currencyPair = tradeCombination.getCurrencyPair();
-
-        Ticker longTicker = tickerService.getTicker(longExchange, currencyPair);
-        Ticker shortTicker = tickerService.getTicker(shortExchange, currencyPair);
-
-        if (tickerService.isInvalidTicker(longTicker) || tickerService.isInvalidTicker(shortTicker)) {
-            return null;
-        }
-
-        BigDecimal spreadIn = computeSpread(longTicker.getAsk(), shortTicker.getBid());
-        BigDecimal spreadOut = computeSpread(longTicker.getBid(), shortTicker.getAsk());
-
-        Spread spread = new Spread(
-            currencyPair,
-            longExchange,
-            shortExchange,
-            longTicker,
-            shortTicker,
-            spreadIn,
-            spreadOut);
-
-        spreadService.publish(spread);
-
-        return spread;
-    }
 
     protected void persistArbitrageToCsvFile(ArbitrageLog arbitrageLog) {
         final File csvFile = new File(TRADE_HISTORY_FILE);

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -77,8 +77,8 @@ public class TradingService {
         this.notificationService = notificationService;
     }
 
-    public void startTradingProcess() {
-        tickerService.getTradeCombinations()
+    public void startTradingProcess(boolean isStreaming) {
+        tickerService.getTradeCombinations(isStreaming)
             .forEach(tradeCombination -> {
                 Spread spread = spreadService.computeSpread(tradeCombination);
 

--- a/src/main/java/com/r307/arbitrader/service/event/StreamingTickerEventListener.java
+++ b/src/main/java/com/r307/arbitrader/service/event/StreamingTickerEventListener.java
@@ -1,0 +1,21 @@
+package com.r307.arbitrader.service.event;
+
+import com.r307.arbitrader.service.TradingService;
+import com.r307.arbitrader.service.model.TickerEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+
+public class StreamingTickerEventListener {
+    private final TradingService tradingService;
+
+    public StreamingTickerEventListener(TradingService tradingService) {
+        this.tradingService = tradingService;
+    }
+
+    @EventListener
+    @Async
+    public void onTradeEvent(TickerEvent tickerEvent) {
+        tradingService.startTradingProcess(tickerEvent.isStreamingExchange());
+    }
+}

--- a/src/main/java/com/r307/arbitrader/service/event/StreamingTickerEventPublisher.java
+++ b/src/main/java/com/r307/arbitrader/service/event/StreamingTickerEventPublisher.java
@@ -1,0 +1,18 @@
+package com.r307.arbitrader.service.event;
+
+import com.r307.arbitrader.service.model.TickerEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StreamingTickerEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public StreamingTickerEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void publishTicker(TickerEvent tickerEvent) {
+        applicationEventPublisher.publishEvent(tickerEvent);
+    }
+}

--- a/src/main/java/com/r307/arbitrader/service/model/TickerEvent.java
+++ b/src/main/java/com/r307/arbitrader/service/model/TickerEvent.java
@@ -1,0 +1,30 @@
+package com.r307.arbitrader.service.model;
+
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.springframework.context.ApplicationEvent;
+
+public class TickerEvent extends ApplicationEvent {
+
+    private final Ticker ticker;
+    private final boolean isStreamingExchange;
+
+    /**
+     * Create a new {@code ApplicationEvent}.
+     *
+     * @param ticker the object on which the event initially occurred or with
+     *               which the event is associated (never {@code null})
+     */
+    public TickerEvent(Ticker ticker, boolean isStreamingExchange) {
+        super(ticker);
+        this.ticker = ticker;
+        this.isStreamingExchange = isStreamingExchange;
+    }
+
+    public Ticker getTicker() {
+        return ticker;
+    }
+
+    public boolean isStreamingExchange() {
+        return isStreamingExchange;
+    }
+}

--- a/src/main/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategy.java
+++ b/src/main/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategy.java
@@ -3,6 +3,7 @@ package com.r307.arbitrader.service.ticker;
 import com.r307.arbitrader.config.NotificationConfiguration;
 import com.r307.arbitrader.service.ErrorCollectorService;
 import com.r307.arbitrader.service.ExchangeService;
+import com.r307.arbitrader.service.TickerService;
 import org.apache.commons.collections4.ListUtils;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -15,7 +16,9 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
@@ -40,8 +43,8 @@ public class ParallelTickerStrategy implements TickerStrategy {
     @Override
     public List<Ticker> getTickers(Exchange exchange, List<CurrencyPair> currencyPairs) {
         MarketDataService marketDataService = exchange.getMarketDataService();
-        Integer tickerBatchDelay = exchangeService.getExchangeMetadata(exchange).getTicker().get("batchDelay");
-        int tickerPartitionSize = exchangeService.getExchangeMetadata(exchange).getTicker()
+        Integer tickerBatchDelay = getTickerExchangeDelay(exchange);
+        int tickerPartitionSize = getTickerPartitionSize(exchange)
             .getOrDefault("batchSize", Integer.MAX_VALUE);
 
         long start = System.currentTimeMillis();
@@ -100,6 +103,14 @@ public class ParallelTickerStrategy implements TickerStrategy {
         }
 
         return tickers;
+    }
+
+    private Integer getTickerExchangeDelay(Exchange exchange) {
+        return exchangeService.getExchangeMetadata(exchange).getTicker().get("batchDelay");
+    }
+
+    private Map<String, Integer> getTickerPartitionSize(Exchange exchange) {
+        return exchangeService.getExchangeMetadata(exchange).getTicker();
     }
 
     @Override

--- a/src/main/java/com/r307/arbitrader/service/ticker/TickerStrategyProvider.java
+++ b/src/main/java/com/r307/arbitrader/service/ticker/TickerStrategyProvider.java
@@ -1,0 +1,39 @@
+package com.r307.arbitrader.service.ticker;
+
+import com.r307.arbitrader.config.NotificationConfiguration;
+import com.r307.arbitrader.service.ErrorCollectorService;
+import com.r307.arbitrader.service.ExchangeService;
+import com.r307.arbitrader.service.event.StreamingTickerEventPublisher;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+@Component
+public class TickerStrategyProvider {
+
+    private final ErrorCollectorService errorCollectorService;
+    private final StreamingTickerEventPublisher streamingTickerEventPublisher;
+    private final NotificationConfiguration notificationConfiguration;
+
+    @Inject
+    public TickerStrategyProvider(ErrorCollectorService errorCollectorService,
+                                  StreamingTickerEventPublisher streamingTickerEventPublisher,
+                                  NotificationConfiguration notificationConfiguration) {
+
+        this.errorCollectorService = errorCollectorService;
+        this.streamingTickerEventPublisher = streamingTickerEventPublisher;
+        this.notificationConfiguration = notificationConfiguration;
+    }
+
+    public TickerStrategy getStreamingTickerStrategy(ExchangeService exchangeService) {
+        return new StreamingTickerStrategy(errorCollectorService, exchangeService, streamingTickerEventPublisher);
+    }
+
+    public TickerStrategy getParallelTickerStrategy(ExchangeService exchangeService) {
+        return new ParallelTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
+    }
+
+    public TickerStrategy getSingleCallTickerStrategy(ExchangeService exchangeService) {
+        return new SingleCallTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
+    }
+}

--- a/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
+++ b/src/test/java/com/r307/arbitrader/ExchangeBuilder.java
@@ -36,8 +36,8 @@ import java.util.UUID;
 
 import static com.r307.arbitrader.DecimalConstants.BTC_SCALE;
 import static com.r307.arbitrader.DecimalConstants.USD_SCALE;
-import static com.r307.arbitrader.service.TradingService.METADATA_KEY;
-import static com.r307.arbitrader.service.TradingService.TICKER_STRATEGY_KEY;
+import static com.r307.arbitrader.service.TradingScheduler.METADATA_KEY;
+import static com.r307.arbitrader.service.TradingScheduler.TICKER_STRATEGY_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -250,7 +250,7 @@ public class ExchangeBuilder {
         return exchange;
     }
 
-    private static List<LimitOrder> generateOrders(CurrencyPair currencyPair, Order.OrderType type) {
+    public static List<LimitOrder> generateOrders(CurrencyPair currencyPair, Order.OrderType type) {
         List<LimitOrder> orders = new ArrayList<>();
 
         for (int i = 0; i < 100; i++) {

--- a/src/test/java/com/r307/arbitrader/service/ExchangeServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ExchangeServiceTest.java
@@ -2,10 +2,7 @@ package com.r307.arbitrader.service;
 
 import com.r307.arbitrader.ExchangeBuilder;
 import com.r307.arbitrader.config.ExchangeConfiguration;
-import com.r307.arbitrader.config.NotificationConfiguration;
-import com.r307.arbitrader.service.ticker.ParallelTickerStrategy;
-import com.r307.arbitrader.service.ticker.SingleCallTickerStrategy;
-import com.r307.arbitrader.service.ticker.TickerStrategy;
+import com.r307.arbitrader.service.ticker.TickerStrategyProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -27,11 +24,9 @@ public class ExchangeServiceTest {
     private ExchangeService exchangeService;
 
     @Mock
-    private NotificationConfiguration notificationConfiguration;
-    @Mock
-    private ErrorCollectorService errorCollectorService;
-    @Mock
     private ExchangeFeeCache exchangeFeeCache;
+    @Mock
+    private TickerStrategyProvider tickerStrategyProvider;
 
     @Before
     public void setUp() throws IOException {
@@ -41,13 +36,7 @@ public class ExchangeServiceTest {
             .withHomeCurrency(Currency.USDT)
             .build();
 
-        TickerStrategy singleCallTickerStrategy = new SingleCallTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
-        TickerStrategy parallelTickerStrategy = new ParallelTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
-        Map<String, TickerStrategy> tickerStrategies = new HashMap<>();
-
-        tickerStrategies.put("singleCallTickerStrategy", singleCallTickerStrategy);
-        tickerStrategies.put("parallelTickerStrategy", parallelTickerStrategy);
-        exchangeService = new ExchangeService(tickerStrategies, exchangeFeeCache);
+        exchangeService = new ExchangeService(exchangeFeeCache, tickerStrategyProvider);
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/ExchangeServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ExchangeServiceTest.java
@@ -31,8 +31,6 @@ public class ExchangeServiceTest {
     @Mock
     private ErrorCollectorService errorCollectorService;
     @Mock
-    private TickerService tickerService;
-    @Mock
     private ExchangeFeeCache exchangeFeeCache;
 
     @Before

--- a/src/test/java/com/r307/arbitrader/service/ExchangeServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ExchangeServiceTest.java
@@ -2,14 +2,21 @@ package com.r307.arbitrader.service;
 
 import com.r307.arbitrader.ExchangeBuilder;
 import com.r307.arbitrader.config.ExchangeConfiguration;
+import com.r307.arbitrader.config.NotificationConfiguration;
+import com.r307.arbitrader.service.ticker.ParallelTickerStrategy;
+import com.r307.arbitrader.service.ticker.SingleCallTickerStrategy;
+import com.r307.arbitrader.service.ticker.TickerStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -19,6 +26,15 @@ public class ExchangeServiceTest {
 
     private ExchangeService exchangeService;
 
+    @Mock
+    private NotificationConfiguration notificationConfiguration;
+    @Mock
+    private ErrorCollectorService errorCollectorService;
+    @Mock
+    private TickerService tickerService;
+    @Mock
+    private ExchangeFeeCache exchangeFeeCache;
+
     @Before
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
@@ -27,7 +43,13 @@ public class ExchangeServiceTest {
             .withHomeCurrency(Currency.USDT)
             .build();
 
-        exchangeService = new ExchangeService();
+        TickerStrategy singleCallTickerStrategy = new SingleCallTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
+        TickerStrategy parallelTickerStrategy = new ParallelTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
+        Map<String, TickerStrategy> tickerStrategies = new HashMap<>();
+
+        tickerStrategies.put("singleCallTickerStrategy", singleCallTickerStrategy);
+        tickerStrategies.put("parallelTickerStrategy", parallelTickerStrategy);
+        exchangeService = new ExchangeService(tickerStrategies, exchangeFeeCache);
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/SpreadServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/SpreadServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ public class SpreadServiceTest {
     @Before
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
+        final TickerService tickerServiceMock = Mockito.mock(TickerService.class);
 
         longExchange = new ExchangeBuilder("Long", CurrencyPair.BTC_USD)
             .withExchangeMetaData()
@@ -28,7 +30,7 @@ public class SpreadServiceTest {
             .withExchangeMetaData()
             .build();
 
-        spreadService = new SpreadService();
+        spreadService = new SpreadService(tickerServiceMock);
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
@@ -7,12 +7,14 @@ import com.r307.arbitrader.service.model.TradeCombination;
 import com.r307.arbitrader.service.ticker.ParallelTickerStrategy;
 import com.r307.arbitrader.service.ticker.SingleCallTickerStrategy;
 import com.r307.arbitrader.service.ticker.TickerStrategy;
+import com.r307.arbitrader.service.ticker.TickerStrategyProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
@@ -39,6 +41,9 @@ public class TickerServiceTest {
     private TickerService tickerService;
     private ExchangeService exchangeService;
 
+    @Mock
+    private TickerStrategyProvider tickerStrategyProvider;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -46,11 +51,7 @@ public class TickerServiceTest {
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
         TradingConfiguration tradingConfiguration = new TradingConfiguration();
 
-        Map<String, TickerStrategy> tickerStrategies = new HashMap<>();
-        tickerStrategies.put("singleCallTickerStrategy", singleCallTickerStrategy);
-        tickerStrategies.put("parallelTickerStrategy", parallelTickerStrategy);
-
-        exchangeService = new ExchangeService(tickerStrategies, new ExchangeFeeCache());
+        exchangeService = new ExchangeService(new ExchangeFeeCache(), tickerStrategyProvider);
         tickerService = new TickerService(
             tradingConfiguration,
             exchangeService,
@@ -176,7 +177,7 @@ public class TickerServiceTest {
 
         tickerService.pollingExchangeTradeCombinations.add(combination);
 
-        List<TradeCombination> result = tickerService.getTradeCombinations(false);
+        List<TradeCombination> result = tickerService.getPollingExchangeTradeCombinations();
 
         assertNotSame(tickerService.pollingExchangeTradeCombinations, result);
         assertTrue(result.contains(combination));

--- a/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
@@ -13,13 +13,16 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,24 +38,31 @@ public class TickerServiceTest {
     private ErrorCollectorService errorCollectorService;
 
     private TickerService tickerService;
+    private ExchangeService exchangeService;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
-        ExchangeService exchangeService = new ExchangeService();
         TradingConfiguration tradingConfiguration = new TradingConfiguration();
+
+        Map<String, TickerStrategy> tickerStrategies = new HashMap<>();
+        tickerStrategies.put("singleCallTickerStrategy", singleCallTickerStrategy);
+        tickerStrategies.put("parallelTickerStrategy", parallelTickerStrategy);
+
+        exchangeService = new ExchangeService(tickerStrategies, new ExchangeFeeCache());
+        tickerService = new TickerService(
+            tradingConfiguration,
+            exchangeService,
+            errorCollectorService);
 
         errorCollectorService = new ErrorCollectorService();
 
         singleCallTickerStrategy = new SingleCallTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
         parallelTickerStrategy = new ParallelTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
 
-        tickerService = new TickerService(
-            tradingConfiguration,
-            exchangeService,
-            errorCollectorService);
+
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
@@ -13,7 +13,6 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
-import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
@@ -83,8 +82,8 @@ public class TickerServiceTest {
 
         tickerService.initializeTickers(exchanges);
 
-        assertEquals(1, tickerService.tradeCombinations.size());
-        assertTrue(tickerService.tradeCombinations.contains(new TradeCombination(exchangeB, exchangeA, CURRENCY_PAIR)));
+        assertEquals(1, tickerService.pollingExchangeTradeCombinations.size());
+        assertTrue(tickerService.pollingExchangeTradeCombinations.contains(new TradeCombination(exchangeB, exchangeA, CURRENCY_PAIR)));
     }
 
     @Test
@@ -102,7 +101,7 @@ public class TickerServiceTest {
             .withMarginSupported(false)
             .build();
 
-        tickerService.tradeCombinations.add(new TradeCombination(exchangeB, exchangeA, CURRENCY_PAIR));
+        tickerService.pollingExchangeTradeCombinations.add(new TradeCombination(exchangeB, exchangeA, CURRENCY_PAIR));
 
         tickerService.refreshTickers();
 
@@ -175,11 +174,11 @@ public class TickerServiceTest {
     public void testGetTradeCombinations() {
         TradeCombination combination = mock(TradeCombination.class);
 
-        tickerService.tradeCombinations.add(combination);
+        tickerService.pollingExchangeTradeCombinations.add(combination);
 
-        List<TradeCombination> result = tickerService.getTradeCombinations();
+        List<TradeCombination> result = tickerService.getTradeCombinations(false);
 
-        assertNotSame(tickerService.tradeCombinations, result);
+        assertNotSame(tickerService.pollingExchangeTradeCombinations, result);
         assertTrue(result.contains(combination));
     }
 

--- a/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TradingServiceTest.java
@@ -67,7 +67,6 @@ public class TradingServiceTest {
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
         final JavaMailSender javaMailSenderMock = mock(JavaMailSender.class);
-//        exchangeService = Mockito.mock(ExchangeService.class);
 
         ObjectMapper objectMapper = new JsonConfiguration().objectMapper();
 
@@ -75,13 +74,6 @@ public class TradingServiceTest {
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
         ErrorCollectorService errorCollectorService = new ErrorCollectorService();
 
-//        TickerStrategy singleCallTickerStrategy = new SingleCallTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
-//        TickerStrategy parallelTickerStrategy = new ParallelTickerStrategy(notificationConfiguration, errorCollectorService, exchangeService);
-//        Map<String, TickerStrategy> tickerStrategies = new HashMap<>();
-//        tickerStrategies.put("singleCallTickerStrategy", singleCallTickerStrategy);
-//        tickerStrategies.put("parallelTickerStrategy", parallelTickerStrategy);
-//
-//        exchangeService = new ExchangeService(tickerStrategies, new ExchangeFeeCache());
         TickerService tickerService = new TickerService(
             new TradingConfiguration(),
             exchangeService,

--- a/src/test/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategyTest.java
@@ -3,18 +3,22 @@ package com.r307.arbitrader.service.ticker;
 import com.r307.arbitrader.ExchangeBuilder;
 import com.r307.arbitrader.config.NotificationConfiguration;
 import com.r307.arbitrader.service.ErrorCollectorService;
+import com.r307.arbitrader.service.ExchangeFeeCache;
 import com.r307.arbitrader.service.ExchangeService;
+import com.r307.arbitrader.service.TickerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -31,7 +35,7 @@ public class ParallelTickerStrategyTest {
         MockitoAnnotations.initMocks(this);
 
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
-        ExchangeService exchangeService = new ExchangeService();
+        ExchangeService exchangeService = new ExchangeService(new HashMap<>(), new ExchangeFeeCache());
 
         errorCollectorService = new ErrorCollectorService();
 

--- a/src/test/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategyTest.java
@@ -11,6 +11,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
@@ -27,13 +28,15 @@ public class ParallelTickerStrategyTest {
     private ErrorCollectorService errorCollectorService;
 
     private TickerStrategy tickerStrategy;
+    @Mock
+    private TickerStrategyProvider tickerStrategyProvider;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
-        ExchangeService exchangeService = new ExchangeService(new HashMap<>(), new ExchangeFeeCache());
+        ExchangeService exchangeService = new ExchangeService(new ExchangeFeeCache(), tickerStrategyProvider);
 
         errorCollectorService = new ErrorCollectorService();
 

--- a/src/test/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/ParallelTickerStrategyTest.java
@@ -5,14 +5,12 @@ import com.r307.arbitrader.config.NotificationConfiguration;
 import com.r307.arbitrader.service.ErrorCollectorService;
 import com.r307.arbitrader.service.ExchangeFeeCache;
 import com.r307.arbitrader.service.ExchangeService;
-import com.r307.arbitrader.service.TickerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;

--- a/src/test/java/com/r307/arbitrader/service/ticker/SingleCallTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/SingleCallTickerStrategyTest.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
@@ -26,12 +27,14 @@ public class SingleCallTickerStrategyTest {
 
     private TickerStrategy tickerStrategy;
 
+    @Mock
+    private ExchangeService exchangeService;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
         NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
-        ExchangeService exchangeService = new ExchangeService();
 
         errorCollectorService = new ErrorCollectorService();
 

--- a/src/test/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategyTest.java
@@ -3,7 +3,7 @@ package com.r307.arbitrader.service.ticker;
 import com.r307.arbitrader.ExchangeBuilder;
 import com.r307.arbitrader.service.ErrorCollectorService;
 import com.r307.arbitrader.service.ExchangeService;
-import com.r307.arbitrader.service.TradingScheduler;
+import com.r307.arbitrader.service.event.StreamingTickerEventPublisher;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -23,15 +23,16 @@ public class StreamingTickerStrategyTest {
     private ErrorCollectorService errorCollectorService;
     @Mock
     private ExchangeService exchangeService;
+    @Mock
+    private StreamingTickerEventPublisher streamingTickerEventPublisher;
 
     private StreamingTickerStrategy streamingTickerStrategy;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        final TradingScheduler tradingSchedulerMock = Mockito.mock(TradingScheduler.class);
 
-        streamingTickerStrategy = new StreamingTickerStrategy(errorCollectorService, exchangeService, tradingSchedulerMock);
+        streamingTickerStrategy = new StreamingTickerStrategy(errorCollectorService, exchangeService, streamingTickerEventPublisher);
     }
 
     @Test

--- a/src/test/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategyTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategyTest.java
@@ -3,12 +3,14 @@ package com.r307.arbitrader.service.ticker;
 import com.r307.arbitrader.ExchangeBuilder;
 import com.r307.arbitrader.service.ErrorCollectorService;
 import com.r307.arbitrader.service.ExchangeService;
+import com.r307.arbitrader.service.TradingScheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
@@ -27,8 +29,9 @@ public class StreamingTickerStrategyTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        final TradingScheduler tradingSchedulerMock = Mockito.mock(TradingScheduler.class);
 
-        streamingTickerStrategy = new StreamingTickerStrategy(errorCollectorService, exchangeService);
+        streamingTickerStrategy = new StreamingTickerStrategy(errorCollectorService, exchangeService, tradingSchedulerMock);
     }
 
     @Test


### PR DESCRIPTION
Refactored SpreadService, TradingService, ExchangeService, ExchangeService.
Added class TradingScheduler

Currently, the app does not start due to a cyclic dependency:
```
┌─────┐
|  exchangeService defined in file [/(...)/arbitrader/build/classes/java/main/com/r307/arbitrader/service/ExchangeService.class]
↑     ↓
|  parallelTickerStrategy defined in file [/(...)/arbitrader/build/classes/java/main/com/r307/arbitrader/service/ticker/ParallelTickerStrategy.class]
└─────┘

```
This is due to the fact `TickerStrategy#getTickers` implemtations requiring a call to `ExchangeService#convertExchangePair`. Ideally we should remove the need to call `ExchangeService#convertExchangePair` from within `TickerStrategy` implementations. This way we remove the cyclic dependency.

Do you have suggestions?