### PR TITLE
streaming trade combinations no longer appear on summary

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/TickerService.java
+++ b/src/main/java/com/r307/arbitrader/service/TickerService.java
@@ -137,6 +137,17 @@ public class TickerService {
         return streamingResult;
     }
 
+    public List<TradeCombination> getAllTradeCombinations() {
+        final List<TradeCombination> result = new ArrayList<>();
+
+        result.addAll(pollingExchangeTradeCombinations);
+        result.addAll(streamingExchangeTradeCombinations);
+
+        Collections.shuffle(result);
+
+        return result;
+    }
+
     // TODO test public API instead of private
     List<Ticker> getTickers(Exchange exchange, List<CurrencyPair> currencyPairs) {
         TickerStrategy tickerStrategy = (TickerStrategy)exchange.getExchangeSpecification().getExchangeSpecificParametersItem(TICKER_STRATEGY_KEY);

--- a/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingScheduler.java
@@ -160,7 +160,7 @@ public class TradingScheduler {
     public void summary() {
         LOGGER.info("Summary: [Long/Short Exchanges] [Pair] [Current Spread] -> [{} Spread Target]", (activePosition != null ? "Exit" : "Entry"));
 
-        List<TradeCombination> tradeCombinations = tickerService.getPollingExchangeTradeCombinations();
+        List<TradeCombination> tradeCombinations = tickerService.getAllTradeCombinations();
 
         tradeCombinations.forEach(tradeCombination -> {
             Spread spread = spreadService.computeSpread(tradeCombination);

--- a/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/TickerServiceTest.java
@@ -172,7 +172,7 @@ public class TickerServiceTest {
     }
 
     @Test
-    public void testGetTradeCombinations() {
+    public void testGetPollingTradeCombinations() {
         TradeCombination combination = mock(TradeCombination.class);
 
         tickerService.pollingExchangeTradeCombinations.add(combination);
@@ -181,6 +181,34 @@ public class TickerServiceTest {
 
         assertNotSame(tickerService.pollingExchangeTradeCombinations, result);
         assertTrue(result.contains(combination));
+    }
+
+    @Test
+    public void testGetStreamingTradeCombinations() {
+        TradeCombination combination = mock(TradeCombination.class);
+
+        tickerService.streamingExchangeTradeCombinations.add(combination);
+
+        List<TradeCombination> result = tickerService.getStreamingExchangeTradeCombinations();
+
+        assertNotSame(tickerService.streamingExchangeTradeCombinations, result);
+        assertTrue(result.contains(combination));
+    }
+
+    @Test
+    public void testGetAllTradeCombinations() {
+        TradeCombination pollingCombination = mock(TradeCombination.class);
+        TradeCombination streamingCombination = mock(TradeCombination.class);
+
+        tickerService.pollingExchangeTradeCombinations.add(pollingCombination);
+        tickerService.streamingExchangeTradeCombinations.add(streamingCombination);
+
+        List<TradeCombination> result = tickerService.getAllTradeCombinations();
+
+        assertNotSame(tickerService.pollingExchangeTradeCombinations, result);
+        assertNotSame(tickerService.streamingExchangeTradeCombinations, result);
+        assertTrue(result.contains(pollingCombination));
+        assertTrue(result.contains(streamingCombination));
     }
 
     @Test


### PR DESCRIPTION
The summary does not appear to be showing trades on streaming exchanges anymore after the last big refactor.