### PR TITLE
pass custom arguments to `getTicker()`

### DIFF
--- a/src/main/java/com/r307/arbitrader/config/ExchangeConfiguration.java
+++ b/src/main/java/com/r307/arbitrader/config/ExchangeConfiguration.java
@@ -25,6 +25,7 @@ public class ExchangeConfiguration {
     private BigDecimal feeOverride;
     private Currency homeCurrency = Currency.USD;
     private Map<String, Integer> ticker = new HashMap<>();
+    private List<Object> tickerArguments = new ArrayList<>();
 
     public String getExchangeClass() {
         return exchangeClass;
@@ -144,5 +145,13 @@ public class ExchangeConfiguration {
 
     public void setTicker(Map<String, Integer> ticker) {
         this.ticker = ticker;
+    }
+
+    public List<Object> getTickerArguments() {
+        return tickerArguments;
+    }
+
+    public void setTickerArguments(List<Object> tickerArguments) {
+        this.tickerArguments = tickerArguments;
     }
 }

--- a/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
+++ b/src/main/java/com/r307/arbitrader/service/ticker/StreamingTickerStrategy.java
@@ -71,8 +71,9 @@ public class StreamingTickerStrategy implements TickerStrategy {
             .stream()
             .map(pair -> {
                 final CurrencyPair currencyPair = exchangeService.convertExchangePair(exchange, pair);
+                final List<Object> tickerArguments = exchangeService.getExchangeMetadata(exchange).getTickerArguments();
 
-                return exchange.getStreamingMarketDataService().getTicker(currencyPair)
+                return exchange.getStreamingMarketDataService().getTicker(currencyPair, tickerArguments.toArray())
                     .doOnNext(ticker -> log(exchange, ticker))
                     .subscribe(
                         ticker -> {


### PR DESCRIPTION
The MarketDataService#getTicker() method has a vararg parameter that is mostly unused, and Arbitrader has simply omitted it up to this point for all exchanges. Unfortunately the streaming MarketDataService for Gemini has a bug where a default value is zero and literally any value greater than zero would solve our problem. If we could just pass a "1" to its `getTicker()` method...

This feature allows a YAML list in your configuration file of constant values to be passed into this `getTicker()` method for a given exchange. It allows a clean workaround of this Gemini bug and I think it may be useful for working around other similar bugs in the future. While the "correct" solution is probably to change the default value in XChange (and I plan to submit a PR for that too) this feature will allow working around it *right now* instead of waiting for the next release of XChange.