### PR TITLE
unify active position

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -126,6 +126,14 @@ public class TradingService {
         }
     }
 
+    public ActivePosition getActivePosition() {
+        return activePosition;
+    }
+
+    public void setActivePosition(ActivePosition activePosition) {
+        this.activePosition = activePosition;
+    }
+
     private void entryPosition(Spread spread, String shortExchangeName, String longExchangeName) {
         final BigDecimal longFees = exchangeService.getExchangeFee(spread.getLongExchange(), spread.getCurrencyPair(), true);
         final BigDecimal shortFees = exchangeService.getExchangeFee(spread.getShortExchange(), spread.getCurrencyPair(), true);


### PR DESCRIPTION
Looks like the ActivePosition got split across TradingService and TradingScheduler which is making the behavior of tracking active positions act strangely, especially if you have quit and restarted the program, because it is being tracked independently in two places. This PR moves ownership of the ActivePosition over to TradingService and makes TradingScheduler access it via getter and setter.