### PR TITLE
Force a trade to open

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/ConditionService.java
+++ b/src/main/java/com/r307/arbitrader/service/ConditionService.java
@@ -15,15 +15,37 @@ import java.util.List;
 
 @Component
 public class ConditionService {
+    static final String FORCE_OPEN = "force-open";
     static final String FORCE_CLOSE = "force-close";
     static final String EXIT_WHEN_IDLE = "exit-when-idle";
     static final String BLACKOUT = "blackout";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConditionService.class);
 
+    private final File forceOpenFile = new File(FORCE_OPEN);
     private final File forceCloseFile = new File(FORCE_CLOSE);
     private final File exitWhenIdleFile = new File(EXIT_WHEN_IDLE);
     private final File blackoutFile = new File(BLACKOUT);
+
+    public boolean isForceOpenCondition() {
+        return forceOpenFile.exists();
+    }
+
+    public String readForceOpenContent() {
+        if (isForceOpenCondition()) {
+            try {
+                return FileUtils.readFileToString(forceOpenFile, Charset.defaultCharset());
+            } catch (IOException e) {
+                LOGGER.warn("IOException reading file '{}': {}", FORCE_OPEN, e.getMessage());
+            }
+        }
+
+        return "";
+    }
+
+    public void clearForceOpenCondition() {
+        FileUtils.deleteQuietly(forceOpenFile);
+    }
 
     public boolean isForceCloseCondition() {
         return forceCloseFile.exists();

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -110,9 +110,31 @@ public class TradingService {
             spread.getCurrencyPair(),
             spread.getIn());
 
-        if (!conditionService.isForceCloseCondition() && spread.getIn().compareTo(tradingConfiguration.getEntrySpread()) > 0) {
+        if (!conditionService.isForceCloseCondition() && (conditionService.isForceOpenCondition() || spread.getIn().compareTo(tradingConfiguration.getEntrySpread()) > 0)) {
             if (activePosition != null) {
                 return;
+            }
+
+            if (conditionService.isForceOpenCondition()) {
+                String exchanges = conditionService.readForceOpenContent().trim();
+
+                /*
+                The force-open file should contain the names of the exchanges you want to force a trade on.
+                It's meant to be a tool to aid testing entry and exit on specific pairs of exchanges.
+
+                In this format: currencyPair longExchange/shortExchange
+                For example: BTC/USD BitFlyer/Kraken
+                */
+                String current = String.format("%s %s/%s",
+                    spread.getCurrencyPair().toString(),
+                    longExchangeName,
+                    shortExchangeName);
+
+                if (!(current).equals(exchanges)) {
+                    return;
+                }
+
+                conditionService.clearForceOpenCondition();
             }
 
             entryPosition(spread, shortExchangeName, longExchangeName);
@@ -206,7 +228,7 @@ public class TradingService {
 
         BigDecimal spreadVerification = spreadService.computeSpread(longLimitPrice, shortLimitPrice);
 
-        if (spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
+        if (!conditionService.isForceOpenCondition() && spreadVerification.compareTo(tradingConfiguration.getEntrySpread()) < 0) {
             LOGGER.debug("Not enough liquidity to execute both trades profitably");
             return;
         }
@@ -221,17 +243,17 @@ public class TradingService {
         BigDecimal totalBalance = logCurrentExchangeBalances(spread.getLongExchange(), spread.getShortExchange());
 
         try {
-        activePosition = new ActivePosition();
-        activePosition.setEntryTime(OffsetDateTime.now());
-        activePosition.setCurrencyPair(spread.getCurrencyPair());
-        activePosition.setExitTarget(exitTarget);
-        activePosition.setEntryBalance(totalBalance);
-        activePosition.getLongTrade().setExchange(spread.getLongExchange());
-        activePosition.getLongTrade().setVolume(longVolume);
-        activePosition.getLongTrade().setEntry(longLimitPrice);
-        activePosition.getShortTrade().setExchange(spread.getShortExchange());
-        activePosition.getShortTrade().setVolume(shortVolume);
-        activePosition.getShortTrade().setEntry(shortLimitPrice);
+            activePosition = new ActivePosition();
+            activePosition.setEntryTime(OffsetDateTime.now());
+            activePosition.setCurrencyPair(spread.getCurrencyPair());
+            activePosition.setExitTarget(exitTarget);
+            activePosition.setEntryBalance(totalBalance);
+            activePosition.getLongTrade().setExchange(spread.getLongExchange());
+            activePosition.getLongTrade().setVolume(longVolume);
+            activePosition.getLongTrade().setEntry(longLimitPrice);
+            activePosition.getShortTrade().setExchange(spread.getShortExchange());
+            activePosition.getShortTrade().setVolume(shortVolume);
+            activePosition.getShortTrade().setEntry(shortLimitPrice);
 
             executeOrderPair(
                     spread.getLongExchange(), spread.getShortExchange(),
@@ -240,13 +262,12 @@ public class TradingService {
                     longVolume, shortVolume,
                     true);
 
-        notificationService.sendEmailNotificationBodyForEntryTrade(spread, exitTarget, longVolume,
-            longLimitPrice, shortVolume, shortLimitPrice);
-
-            } catch (IOException e) {
-                LOGGER.error("IOE executing limit orders: ", e);
-                activePosition = null;
-            }
+            notificationService.sendEmailNotificationBodyForEntryTrade(spread, exitTarget, longVolume,
+                longLimitPrice, shortVolume, shortLimitPrice);
+        } catch (IOException e) {
+            LOGGER.error("IOE executing limit orders: ", e);
+            activePosition = null;
+        }
 
         try {
             FileUtils.write(new File(STATE_FILE), objectMapper.writeValueAsString(activePosition), Charset.defaultCharset());
@@ -271,18 +292,20 @@ public class TradingService {
         final String shortExchangeName = spread.getShortExchange().getExchangeSpecification().getExchangeName();
 
         if (maxExposure.compareTo(longMinAmount) <= 0) {
-            LOGGER.error("{} must have more than ${} to trade {}",
+            LOGGER.error("{} must have at least ${} to trade {} but only has ${}",
                 longExchangeName,
                 longMinAmount.add(longMinAmount.multiply(TRADE_REMAINDER)),
-                longCurrencyPair);
+                longCurrencyPair,
+                maxExposure);
             return false;
         }
 
         if (maxExposure.compareTo(shortMinAmount) <= 0) {
-            LOGGER.error("{} must have more than ${} to trade {}",
+            LOGGER.error("{} must have at least ${} to trade {} but only has ${}",
                 shortExchangeName,
                 shortMinAmount.add(shortMinAmount.multiply(TRADE_REMAINDER)),
-                shortCurrencyPair);
+                shortCurrencyPair,
+                maxExposure);
             return false;
         }
 
@@ -434,7 +457,13 @@ public class TradingService {
 
     private void logEntryTrade(Spread spread, String shortExchangeName, String longExchangeName, BigDecimal exitTarget,
                                BigDecimal longVolume, BigDecimal shortVolume, BigDecimal longLimitPrice, BigDecimal shortLimitPrice) {
-        LOGGER.info("***** ENTRY *****");
+
+        if (conditionService.isForceOpenCondition()) {
+            LOGGER.warn("***** FORCED ENTRY *****");
+        } else {
+            LOGGER.info("***** ENTRY *****");
+        }
+
         LOGGER.info("Entry spread: {}", spread.getIn());
         LOGGER.info("Exit spread target: {}", exitTarget);
         LOGGER.info("Long entry: {} {} {} @ {} ({} slip) = {}{}",

--- a/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
+++ b/src/test/java/com/r307/arbitrader/service/ConditionServiceTest.java
@@ -13,12 +13,12 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static com.r307.arbitrader.service.ConditionService.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 public class ConditionServiceTest {
@@ -45,6 +45,55 @@ public class ConditionServiceTest {
     @AfterClass
     public static void tearDown() {
         FileUtils.deleteQuietly(new File(BLACKOUT));
+    }
+
+    @Test
+    public void testClearForceOpenConditionIdempotence() {
+        // it should not break if the condition is already clear
+        conditionService.clearForceOpenCondition();
+    }
+
+    @Test
+    public void testClearForceOpenCondition() throws IOException {
+        File forceOpen = new File(FORCE_OPEN);
+
+        assertTrue(forceOpen.createNewFile());
+        assertTrue(forceOpen.exists());
+
+        conditionService.clearForceOpenCondition();
+
+        assertFalse(forceOpen.exists());
+    }
+
+    @Test
+    public void testCheckForceOpenCondition() throws IOException {
+        File forceOpen = new File(FORCE_OPEN);
+
+        assertFalse(forceOpen.exists());
+        assertFalse(conditionService.isForceOpenCondition());
+
+        assertTrue(forceOpen.createNewFile());
+
+        assertTrue(forceOpen.exists());
+        assertTrue(conditionService.isForceOpenCondition());
+
+        FileUtils.deleteQuietly(forceOpen);
+    }
+
+    @Test
+    public void testReadForceOpenContent() throws IOException {
+        String data = "BitFlyer/Kraken";
+        File forceOpen = new File(FORCE_OPEN);
+
+        assertFalse(forceOpen.exists());
+        assertFalse(conditionService.isForceOpenCondition());
+
+        FileUtils.writeStringToFile(forceOpen, data, Charset.defaultCharset());
+        assertTrue(conditionService.isForceOpenCondition());
+
+        assertEquals(data, conditionService.readForceOpenContent());
+
+        FileUtils.deleteQuietly(forceOpen);
     }
 
     @Test


### PR DESCRIPTION
You can now create a file while the bot is running and tell it to open a trade on a specific currency, between two specific exchanges, even if the spread isn't good enough to trade automatically.

The intended use for this is to aid in testing when the market isn't cooperating. I've been trying to test trade exits on BitFlyer for weeks now but my bot hasn't wanted to trade. Now I can make it open the trade anyway and use `force-close` to make it exit, so I can test the trade volume logic regardless of market conditions.