### PR TITLE
get currency scale from exchange metadata

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -202,7 +202,7 @@ public class TradingService {
             return;
         }
 
-        // Figure out the scale (number of decimal places) for each exchange base on its CurrencyMetaData.
+        // Figure out the scale (number of decimal places) for each exchange based on its CurrencyMetaData.
         // If there is no metadata, fall back to BTC's default of 8 places that should work in most cases.
         final CurrencyMetaData defaultMetaData = new CurrencyMetaData(BTC_SCALE, BigDecimal.ZERO);
         final int longScale = spread

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -202,6 +202,8 @@ public class TradingService {
             return;
         }
 
+        // Figure out the scale (number of decimal places) for each exchange base on its CurrencyMetaData.
+        // If there is no metadata, fall back to BTC's default of 8 places that should work in most cases.
         final CurrencyMetaData defaultMetaData = new CurrencyMetaData(BTC_SCALE, BigDecimal.ZERO);
         final int longScale = spread
             .getLongExchange()

--- a/src/main/java/com/r307/arbitrader/service/TradingService.java
+++ b/src/main/java/com/r307/arbitrader/service/TradingService.java
@@ -15,6 +15,7 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
@@ -201,8 +202,19 @@ public class TradingService {
             return;
         }
 
-        final int longScale = spread.getLongExchange().getExchangeMetaData().getCurrencies().get(currencyPairLongExchange.base).getScale();
-        final int shortScale = spread.getShortExchange().getExchangeMetaData().getCurrencies().get(currencyPairShortExchange.base).getScale();
+        final CurrencyMetaData defaultMetaData = new CurrencyMetaData(BTC_SCALE, BigDecimal.ZERO);
+        final int longScale = spread
+            .getLongExchange()
+            .getExchangeMetaData()
+            .getCurrencies()
+            .getOrDefault(currencyPairLongExchange.base, defaultMetaData)
+            .getScale();
+        final int shortScale = spread
+            .getShortExchange()
+            .getExchangeMetaData()
+            .getCurrencies()
+            .getOrDefault(currencyPairShortExchange.base, defaultMetaData)
+            .getScale();
 
         LOGGER.debug("Max exposure: {}", maxExposure);
         LOGGER.debug("Long scale: {}", longScale);


### PR DESCRIPTION
instead of assuming it's always 8

My bot tried to trade XRP/USD on CoinbasePro last night and it failed because Coinbase only allows a scale of 6.