### PR TITLE
Correct fee calculation

### DIFF
--- a/src/main/java/com/r307/arbitrader/service/paper/PaperTradeService.java
+++ b/src/main/java/com/r307/arbitrader/service/paper/PaperTradeService.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.service.trade.params.orders.OrderQueryParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -152,7 +153,7 @@ public class PaperTradeService extends BaseExchangeService<PaperExchange> implem
         order.setOrderStatus(Order.OrderStatus.FILLED);
         order.setAveragePrice(order.getLimitPrice());
         order.setCumulativeAmount(order.getOriginalAmount());
-        order.setFee(order.getCumulativeCounterAmount().multiply(exchangeService.getExchangeFee(exchange,order.getCurrencyPair(),false)));
+        order.setFee(order.getCumulativeCounterAmount().multiply(exchangeService.getExchangeFee(exchange,order.getCurrencyPair(),false).divide(new BigDecimal("100"))));
         LOGGER.info("{} paper exchange: Order {} filled for {}{}, with {} fees.",
             exchange.getExchangeSpecification().getExchangeName(),
             order.getId(),


### PR DESCRIPTION
The paper trading fee calculation was incorrect: the exchange fee is expressed in percentage, hence need to be divided by 100 before multiplying.